### PR TITLE
Only parse known args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "multiconn_archicad"
-version = "0.3.1"
+version = "0.3.2"
 description = "MultiConn ArchiCAD is a connection object for ArchiCAD’s JSON API and its Python wrapper, designed to manage multiple open instances of ArchiCAD simultaneously."
 readme = "README.md"
 authors = [

--- a/src/multiconn_archicad/core_commands.py
+++ b/src/multiconn_archicad/core_commands.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, Coroutine, TYPE_CHECKING
 import aiohttp
 import asyncio
 import logging
-import argparse
 
 from multiconn_archicad.errors import (
     CommandTimeoutError,
@@ -16,22 +15,20 @@ from multiconn_archicad.errors import (
 )
 from multiconn_archicad.utilities.async_utils import run_sync
 from multiconn_archicad.basic_types import Port
+from multiconn_archicad.utilities.cli_pharser import get_cli_args_once
 
 if TYPE_CHECKING:
     from multiconn_archicad.literal_commands import AddonCommandType, TapirCommandType
 
 
 log = logging.getLogger(__name__)
-parser = argparse.ArgumentParser()
-parser.add_argument("--host", dest="host", type=str, default="http://127.0.0.1")
-parser.add_argument("--port", dest="port", type=int, default=19723)
-args = parser.parse_args()
 
 
 class CoreCommands:
-    def __init__(self, port: Port = Port(args.port), host: str = args.host):
-        self.port: Port = port
-        self.url: str = f"{host}:{self.port}"
+    def __init__(self, port: Port = Port(19723), host: str = "http://127.0.0.1"):
+        cli_args = get_cli_args_once()
+        self.port: Port = Port(cli_args.port) if cli_args.port else port
+        self.url: str = f"{cli_args.host if cli_args.host else host}:{self.port}"
 
     def __repr__(self) -> str:
         attrs = ", ".join(f"{k}={v!r}" for k, v in vars(self).items())

--- a/src/multiconn_archicad/multi_conn.py
+++ b/src/multiconn_archicad/multi_conn.py
@@ -1,7 +1,6 @@
 import asyncio
 import aiohttp
 from pprint import pformat
-import argparse
 
 from multiconn_archicad.utilities.async_utils import run_sync
 from multiconn_archicad.core_commands import CoreCommands
@@ -18,21 +17,19 @@ from multiconn_archicad.actions import (
     SwitchProject,
 )
 from multiconn_archicad.dialog_handlers import DialogHandlerBase, EmptyDialogHandler
+from multiconn_archicad.utilities.cli_pharser import get_cli_args_once
 
 import logging
 
 log = logging.getLogger(__name__)
-parser = argparse.ArgumentParser()
-parser.add_argument("--host", dest="host", type=str, default="http://127.0.0.1")
-parser.add_argument("--port", dest="port", type=int, default=None)
-args = parser.parse_args()
-args.port = Port(args.port) if args.port else None
+
 
 class MultiConn:
     _port_range: list[Port] = [Port(port) for port in range(19723, 19744)]
 
-    def __init__(self, dialog_handler: DialogHandlerBase = EmptyDialogHandler(), port: Port | None = args.port, host: str = args.host) -> None:
-        self._base_url: str = host
+    def __init__(self, dialog_handler: DialogHandlerBase = EmptyDialogHandler(), port: Port | None = None, host: str = "http://127.0.0.1") -> None:
+        cli_args = get_cli_args_once()
+        self._base_url: str = cli_args.host if cli_args.host else host
         self.open_port_headers: dict[Port, ConnHeader] = {}
         self._primary: ConnHeader | None = None
         self.dialog_handler: DialogHandlerBase = dialog_handler
@@ -51,6 +48,7 @@ class MultiConn:
         self.switch_project: SwitchProject = SwitchProject(self)
 
         self.refresh.all_ports()
+        port = Port(cli_args.port) if cli_args.port else port
         run_sync(self._set_primary(port))
 
     @property

--- a/src/multiconn_archicad/utilities/cli_parser.py
+++ b/src/multiconn_archicad/utilities/cli_parser.py
@@ -1,0 +1,59 @@
+import argparse
+import sys
+import logging
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+_cli_parser = argparse.ArgumentParser(
+    description="Multiconn-Archicad CLI options",
+    allow_abbrev=False,
+)
+_cli_parser.add_argument(
+    "--host",
+    dest="host",
+    type=str,
+    default="http://127.0.0.1",
+    help="Used to set the host for Archicad JSON API (default: http://127.0.0.1)"
+)
+_cli_parser.add_argument(
+    "--port",
+    dest="port",
+    type=int,
+    default=None,
+    help="Used to set the port for Archicad JSON API (default: None)"
+)
+
+_parsed_cli_args_cache: Optional[argparse.Namespace] = None
+
+
+def get_cli_args_once() -> argparse.Namespace:
+    """
+    Parses command-line arguments relevant to multiconn_archicad (--host, --port)
+    once and caches the result. Ignores unknown arguments.
+    Returns a namespace with defaults if parsing fails or if --host/--port are not provided.
+    """
+    global _parsed_cli_args_cache
+    if _parsed_cli_args_cache is not None:
+        return _parsed_cli_args_cache
+
+    args_to_parse: list[str] = sys.argv[1:]
+
+    try:
+        parsed_args, unknown_args = _cli_parser.parse_known_args(args=args_to_parse)
+
+        if unknown_args:
+            log.debug(
+                f"multiconn_archicad.cli_parser encountered unknown arguments: {unknown_args}. "
+                "These will be ignored by multiconn_archicad."
+            )
+        _parsed_cli_args_cache = parsed_args
+    except Exception as e:
+        log.warning(
+            f"Failed to parse CLI arguments for multiconn_archicad due to an error: {e}. "
+            "Using default values for --host and --port."
+        )
+        # Create a namespace with default values
+        _parsed_cli_args_cache = _cli_parser.parse_args([])
+
+    return _parsed_cli_args_cache


### PR DESCRIPTION
- argument parsing moved to cli_parser.py
- we are now only parsing known args for pyinstaller compatibility and the option to allow for potential other args for scripts