### PR TITLE
feat: implemented an import time plugin system that lets users configure the behaviour of APIBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ## Features
 
 - **Unified High-Level API**: Modern, Pydantic-validated interface for both Official and Tapir APIs.
+- **Dynamic Model Configuration**: Configurable Pydantic mixins for strict validation (MCP / AI agents), immutability, and data cleaning.
 - **Multi-instance Management**: Seamlessly execute commands across one, several, or all open Archicad projects.
 - **Project Automation**: Programmatically find, open, and switch between solo and teamwork projects.
 - **Thread-Safe Architecture**: Built on a synchronous threading model using `httpx` for maximum stability and performance.
@@ -72,11 +73,11 @@ if isinstance(info, PendingResponse):
 
 The library provides three distinct namespaces for interacting with Archicad, each suited for different needs. 
 
-*   **`unified`**: A high-level, type-safe and pythonic interface that unifies both the Official and Tapir APIs into a single, easy-to-use framework
+*   **`unified`**: A high-level, type-safe and pythonic interface that unifies both the Official and Tapir APIs into a single, easy-to-use framework.
 *   **`core`**: A low-level interface for sending raw JSON commands.
 *   **`standard`**: The official ArchiCAD python wrapper.
 
-By incorporating the 3 namespaces to a common framework it is possible to freely mix them, allowing you to reuse codes of different styles.
+By incorporating the 3 namespaces into a common framework it is possible to freely mix them, allowing you to reuse code of different styles.
 
 #### Example: Using two namespaces together
 ```python
@@ -90,6 +91,8 @@ def run(conn: MultiConn | ConnHeader) -> dict[str, Any]:
     }
     return conn.core.post_tapir_command('HighlightElements', command_parameters)
 ```
+
+---
 
 ### 1. The `unified` Namespace (Recommended)
 
@@ -112,7 +115,7 @@ from multiconn_archicad.models.official import types as official_types
 conn = MultiConn()
 assert conn.primary, "No running Archicad instance found."
 
-# Create a shortcut to the official_commands commands for convenience
+# Create a shortcut to the official commands for convenience
 official_commands = conn.primary.unified.official
 
 # 1. Get identifiers for all elements
@@ -141,6 +144,95 @@ property_values_for_elements = [
 
 print(f"Retrieved Element IDs for {len(property_values_for_elements)} elements.")
 ```
+
+### Model Configuration & Mixins (Unified API)
+
+By default, all `unified` Pydantic models use **lenient parsing (`extra="ignore"`)**. This ensures forward compatibility so that newly added fields from Tapir/Archicad updates will not break your application or data pipelines.
+
+For workflows that require custom validation, immutability, or extra functionality, you can configure `APIModel` behavior at import time using `configure()`.
+
+#### How to Configure
+
+`configure()` **must** be called before importing any model classes (`commands`, `types`, etc.). If called after models are already imported and compiled, it will raise a `RuntimeError` to prevent silent configuration drift.
+
+```python
+from multiconn_archicad.models.config import configure
+from multiconn_archicad.models.mixins import (
+    StrictValidationMixin,
+    FrozenMixin,
+    StripWhitespaceMixin,
+    OmitDefaultsMixin,
+)
+
+# Configure the base models for your application
+configure(StrictValidationMixin, StripWhitespaceMixin)
+
+# Now safely import model classes (this locks the configuration)
+from multiconn_archicad.models.tapir.commands import CreateBeamsParameters
+from multiconn_archicad.models.tapir.types import Coordinate2D
+```
+
+#### Built-in Mixins
+
+The library includes several common mixins out-of-the-box:
+
+| Mixin | Purpose | Common Use Case |
+| :--- | :--- | :--- |
+| **`StrictValidationMixin`** | Forbids unexpected/extra fields on models. Raises `ValueError` on extra input keys. | **MCP Servers / LLM Tool Calling** to catch hallucinated parameters. |
+| **`FrozenMixin`** | Sets `frozen=True` on all models, making them immutable and hashable. | Thread safety, using models in `set()` or as `dict` keys. |
+| **`StripWhitespaceMixin`** | Automatically strips leading and trailing whitespace from all string fields. | Cleaning up messy user-entered BIM data. |
+| **`OmitDefaultsMixin`** | Excludes fields with default/None values from `.model_dump()` and `.model_dump_json()`. | Minimizing HTTP payload sizes. |
+
+#### Creating Custom Mixins
+
+The built-in mixins are just examples—**you can freely define and combine your own custom mixins**. Any class inheriting from Pydantic's `BaseModel` can be injected to add custom methods, validators, or attributes across the entire model catalog:
+
+```python
+from typing import Any
+from pydantic import BaseModel, PrivateAttr
+from multiconn_archicad.models.config import configure
+from multiconn_archicad.models.mixins import StrictValidationMixin
+
+# 1. Define a custom mixin (e.g., track fields modified after instantiation)
+class DirtyTrackingMixin(BaseModel):
+    _dirty_fields: set[str] = PrivateAttr(default_factory=set)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if getattr(self, name, object()) != value:
+            self._dirty_fields.add(name)
+        super().__setattr__(name, value)
+
+    def get_changes(self) -> dict[str, Any]:
+        """Returns only the fields that were modified."""
+        return self.model_dump(include=self._dirty_fields)
+
+# 2. Combine built-in and custom mixins together
+configure(StrictValidationMixin, DirtyTrackingMixin)
+
+# 3. Import models — all generated models now inherit both mixins
+from multiconn_archicad.models.tapir.types import WallData, Coordinate2D
+
+wall = WallData(
+    begCoordinate=Coordinate2D(x=0, y=0),
+    endCoordinate=Coordinate2D(x=10, y=0),
+    zCoordinate=0.0,
+    height=3.0,
+    thickness=0.3,
+)
+wall.height = 3.5
+print(wall.get_changes())  # {'height': 3.5}
+```
+
+#### Strict Mode & Bypasses
+
+When using `StrictValidationMixin`:
+1. **Context-based lenient bypass:** You can still parse raw API responses leniently by passing `context={"ignore_extra_keys": True}`:
+   ```python
+   data = Coordinate2D.model_validate(api_json, context={"ignore_extra_keys": True})
+   ```
+2. **Intentional dynamic models:** Models that explicitly require arbitrary keys (e.g., `AddOnCommandParameters`, `AddOnCommandResponse`) retain `extra="allow"` and are never blocked by strict mode.
+
+---
 
 ### 2. The `core` Namespace (Low-Level)
 
@@ -193,9 +285,13 @@ incorrect_params = {
 highlight_elements(conn, incorrect_params) # <-- STATIC ERROR!
 ```
 
+---
+
 ### 3. The `standard` Namespace (Legacy)
 
-This namespace provides direct access to Archicad's official Python wrapper. It is maintained for backward compatibility with older scripts but is not recommended for new projects, as the `unified` API incorporates all it's features, and covers the Tapir commands as well.
+This namespace provides direct access to Archicad's official Python wrapper. It is maintained for backward compatibility with older scripts but is not recommended for new projects, as the `unified` API incorporates all its features and covers Tapir commands as well.
+
+---
 
 ### Running Commands
 
@@ -245,6 +341,8 @@ elements = {
 }
 ```
 
+---
+
 ### Connection Management
 
 MultiConn tracks every open Archicad instance. You can access these via specific filters:
@@ -256,7 +354,6 @@ MultiConn tracks every open Archicad instance. You can access these via specific
 #### Example: Parallel Execution
 ```python
 from multiconn_archicad import MultiConn, Port
-
 
 conn = MultiConn()
 
@@ -272,6 +369,8 @@ conn.refresh.closed_ports()
 # Quit an Archicad instance
 conn.quit.from_headers(conn.open_port_headers[Port(19735)])
 ```
+
+---
 
 ### Project Management
 
@@ -380,7 +479,7 @@ Note: Passwords are not stored in serialized connection headers for security rea
 
 ```python
 import json
-from multiconn_archicad import ConnHeader
+from multiconn_archicad import ConnHeader, TeamworkCredentials, TeamworkProjectID
 
 with open('conn_header.json', 'r') as f:
     header_dict = json.load(f)
@@ -394,6 +493,8 @@ if isinstance(conn_header.archicad_id, TeamworkProjectID):
     # Use the credentials when opening the project
     port = conn.open_project.with_teamwork_credentials(conn_header, credentials)
 ```
+
+---
 
 ### Error Handling
 
@@ -437,6 +538,8 @@ except APIErrorBase as e:
      print(f"An API error occurred: Code={e.code}, Message='{e.message}'")
 
 ```
+
+---
 
 ## Contributing
 

--- a/src/multiconn_archicad/models/base.py
+++ b/src/multiconn_archicad/models/base.py
@@ -1,10 +1,14 @@
 from typing import Any
 from pydantic import BaseModel, ConfigDict
+from .config import _Registry
 
-class APIModel(BaseModel):
+_bases = _Registry.mixins + (BaseModel,)
+
+class APIModel(*_bases):
     """A custom base model for the Unified API"""
+
     model_config = ConfigDict(
-        extra="forbid",
+        extra="ignore",
         populate_by_name=True,
         serialize_by_alias=True,
     )
@@ -34,3 +38,8 @@ class APIModel(BaseModel):
             exclude_none=exclude_none,
             **kwargs,
         )
+
+# =====================================================================
+# LOCK CONFIGURATION
+# =====================================================================
+_Registry.locked = True

--- a/src/multiconn_archicad/models/config.py
+++ b/src/multiconn_archicad/models/config.py
@@ -1,0 +1,19 @@
+class _Registry:
+    mixins: tuple[type, ...] = ()
+    locked: bool = False
+
+
+def configure(*mixins: type):
+    """
+    Configure the behavior of the API models by injecting Mixins.
+
+    MUST be called before importing any models from the package.
+    Example: `configure(StrictValidationMixin, FrozenMixin)`
+    """
+    if _Registry.locked:
+        raise RuntimeError(
+            "archicad_models configure() was called AFTER model classes were already built "
+            "(something imported the models before you configured it). "
+            "Call configure() before any multiconn_archicad model imports."
+        )
+    _Registry.mixins = mixins

--- a/src/multiconn_archicad/models/mixins.py
+++ b/src/multiconn_archicad/models/mixins.py
@@ -1,0 +1,75 @@
+from typing import Any
+from pydantic import BaseModel, ConfigDict, model_validator, ValidationInfo
+
+_MODEL_KEYS_CACHE: dict[type, set[str]] = {}
+
+class StrictValidationMixin(BaseModel):
+    """
+    Enforces strict validation by rejecting unknown keys that can be turned off using validation context.
+    Designed for MCP Servers / LLM inputs.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def forbid_extras_unless_api(cls, data: Any, info: ValidationInfo):
+        if info.context and info.context.get("ignore_extra_keys"):
+            return data
+        if cls.model_config.get("extra") == "allow":
+            return data
+
+        if isinstance(data, dict):
+            allowed_keys = _MODEL_KEYS_CACHE.get(cls)
+            if allowed_keys is None:
+                allowed_keys = set(cls.model_fields.keys())
+                for field in cls.model_fields.values():
+                    if field.alias:
+                        allowed_keys.add(field.alias)
+                _MODEL_KEYS_CACHE[cls] = allowed_keys
+
+            extra_keys = data.keys() - allowed_keys
+            if extra_keys:
+                raise ValueError(
+                    f"Extra fields not allowed in {cls.__name__}: {', '.join(extra_keys)}"
+                )
+
+        return data
+
+
+class FrozenMixin(BaseModel):
+    """
+    Makes all models immutable and hashable.
+    Useful for using models as dictionary keys, in sets, or for thread safety.
+    """
+    model_config = ConfigDict(frozen=True)
+
+
+class StripWhitespaceMixin(BaseModel):
+    """
+    Automatically strips leading and trailing whitespace from all string fields.
+    Extremely useful for cleaning up human-entered BIM data.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def strip_strings(cls, data: Any):
+        if isinstance(data, dict):
+            data = dict(data)
+            for key, value in data.items():
+                if isinstance(value, str):
+                    data[key] = value.strip()
+        return data
+
+
+class OmitDefaultsMixin(BaseModel):
+    """
+    Overrides dumping so that fields with default values are NOT included in the JSON payload.
+    Highly useful for minimizing HTTP payload sizes.
+    """
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        kwargs.setdefault("exclude_defaults", True)
+        return super().model_dump(**kwargs)
+
+    def model_dump_json(self, **kwargs: Any) -> str:
+        kwargs.setdefault("exclude_defaults", True)
+        return super().model_dump_json(**kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,13 +6,13 @@ from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 import concurrent.futures
 from pathlib import Path
 from typing import Dict, Any, Callable
-
 import pytest
 
-# Import modules for configuration patching
 import multiconn_archicad.multi_conn as multi_conn
 import multiconn_archicad.utilities.cli_parser as cli_parser
 from multiconn_archicad.basic_types import Port
+from multiconn_archicad.models import config
+from multiconn_archicad.models.mixins import _MODEL_KEYS_CACHE
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -212,3 +212,28 @@ def pytest_sessionstart(session):
         print(" before executing the test suite to prevent socket-routing test interference.")
         print("=" * 80 + "\n")
         sys.exit(1)
+
+
+@pytest.fixture
+def clean_models():
+    """
+    Ensures that the models package is completely unimported and reset
+    before and after the test runs.
+    """
+
+    def _unload():
+        config._Registry.locked = False
+        config._Registry.mixins = ()
+        _MODEL_KEYS_CACHE.clear()
+
+        # Pop all multiconn_archicad model modules EXCEPT config
+        to_delete = [
+            name for name in sys.modules
+            if name.startswith("multiconn_archicad.models") and not name.endswith(".config")
+        ]
+        for mod in to_delete:
+            del sys.modules[mod]
+
+    _unload()
+    yield
+    _unload()

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -1,0 +1,262 @@
+import sys
+import subprocess
+import pytest
+from pydantic import ValidationError
+
+
+# =========================================================================
+# REQUIREMENT 1: configure() raises if models are already imported
+# =========================================================================
+
+def test_configure_after_import_raises_runtime_error(clean_models):
+    """Verifies that the lock triggers immediately if configure() is called late."""
+    from multiconn_archicad.models.config import configure
+
+    # 1. Import a model class -> triggers __init_subclass__ -> locks registry
+    import multiconn_archicad.models.tapir.commands
+
+    # 2. Attempting to configure now MUST fail loudly
+    with pytest.raises(RuntimeError, match="called AFTER model classes were already built"):
+        configure()
+
+
+def test_lock_enforcement_in_isolated_process():
+    """Airtight subprocess test: simulates a user making an import-order mistake in a real script."""
+    code = """
+import multiconn_archicad.models.tapir.commands
+from multiconn_archicad.models.config import configure
+from multiconn_archicad.models.mixins import StrictValidationMixin
+
+# This must raise RuntimeError and exit with an error code
+configure(StrictValidationMixin)
+"""
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode != 0
+    assert "called AFTER model classes were already built" in result.stderr
+
+
+def test_importing_base_locks_registry_immediately(clean_models):
+    """
+    Verifies that importing base.py (which compiles APIModel)
+    immediately locks the registry before any subclass is even defined.
+    """
+    from multiconn_archicad.models.config import configure
+
+    # 1. Import base directly (APIModel compiles here)
+    import multiconn_archicad.models.base
+
+    # 2. Calling configure now MUST raise RuntimeError immediately
+    with pytest.raises(RuntimeError, match="called AFTER model classes were already built"):
+        configure()
+
+
+# =========================================================================
+# REQUIREMENT 2: Importing config / root library does NOT load models
+# =========================================================================
+
+def test_importing_config_does_not_lock_or_import_models(clean_models):
+    """Verifies that importing config.py is completely passive."""
+    # 1. Import config
+    import multiconn_archicad.models.config as config
+
+    # 2. Ensure lock is NOT engaged
+    assert config._Registry.locked is False
+
+    # 3. Ensure no model files were transitively loaded into sys.modules
+    assert "multiconn_archicad.models.base" not in sys.modules
+    assert "multiconn_archicad.models.types" not in sys.modules
+    assert "multiconn_archicad.models.commands" not in sys.modules
+
+
+# =========================================================================
+# REQUIREMENT 3: Mixins properly alter model behavior
+# =========================================================================
+
+def test_strict_validation_mixin_alters_behavior(clean_models):
+    """Verifies StrictValidationMixin rejects unknown keys but respects context bypass."""
+    from multiconn_archicad.models.config import configure
+    from multiconn_archicad.models.mixins import StrictValidationMixin
+
+    # Configure strict mode
+    configure(StrictValidationMixin)
+
+    from multiconn_archicad.models.tapir.types import Coordinate2D
+
+    # 1. Unknown field -> Must raise ValueError
+    with pytest.raises(ValueError, match="Extra fields not allowed in Coordinate2D"):
+        Coordinate2D(x=1.0, y=2.0, fake_z_coordinate=3.0)
+
+    # 2. Context bypass -> Must safely ignore unknown field
+    valid_with_context = Coordinate2D.model_validate(
+        {"x": 1.0, "y": 2.0, "future_api_field": "test"},
+        context={"ignore_extra_keys": True}
+    )
+    assert valid_with_context.x == 1.0
+
+
+def test_frozen_mixin_alters_behavior(clean_models):
+    """Verifies FrozenMixin makes models immutable and hashable."""
+    from multiconn_archicad.models.config import configure
+    from multiconn_archicad.models.mixins import FrozenMixin
+
+    configure(FrozenMixin)
+
+    from multiconn_archicad.models.tapir.types import Coordinate2D
+
+    coord = Coordinate2D(x=10.0, y=20.0)
+
+    # 1. Mutation must raise ValidationError
+    with pytest.raises(ValidationError):
+        coord.x = 99.0
+
+    # 2. Must be hashable (usable in sets / dict keys)
+    coord_set = {coord}
+    assert coord in coord_set
+
+
+def test_omit_defaults_mixin_alters_behavior(clean_models):
+    """Verifies OmitDefaultsMixin excludes default values from dumps."""
+    from multiconn_archicad.models.config import configure
+    from multiconn_archicad.models.mixins import OmitDefaultsMixin
+
+    configure(OmitDefaultsMixin)
+
+    from multiconn_archicad.models.tapir.types import BeamData, Coordinate2D
+
+    # BeamData has many optional fields defaulting to None (e.g. offset, slantAngle)
+    beam = BeamData(
+        begCoordinate=Coordinate2D(x=0.0, y=0.0),
+        endCoordinate=Coordinate2D(x=5.0, y=0.0),
+        zCoordinate=0.0,
+    )
+
+    dumped = beam.model_dump()
+
+    # Defaults like slantAngle (None) should be omitted
+    assert "slantAngle" not in dumped
+    assert "begCoordinate" in dumped
+
+
+def test_multiple_mixins_combine_cooperatively(clean_models):
+    """
+    Verifies that all 4 mixins (Strict, Frozen, StripWhitespace, OmitDefaults)
+    can be configured together and that all their behaviors execute simultaneously.
+    """
+    from multiconn_archicad.models.config import configure
+    from multiconn_archicad.models.mixins import (
+        StrictValidationMixin,
+        FrozenMixin,
+        StripWhitespaceMixin,
+        OmitDefaultsMixin,
+    )
+
+    # 1. Configure with all 4 mixins simultaneously
+    configure(
+        StrictValidationMixin,
+        FrozenMixin,
+        StripWhitespaceMixin,
+        OmitDefaultsMixin,
+    )
+
+    from multiconn_archicad.models.tapir.types import DetailData, BeamData, Coordinate2D
+
+    # =========================================================================
+    # BEHAVIOR 1: StripWhitespaceMixin (Trims whitespace from strings)
+    # =========================================================================
+    detail = DetailData(
+        name="   Foundation Detail A-A   ",
+        referenceId="   DET-001   ",
+    )
+    assert detail.name == "Foundation Detail A-A"
+    assert detail.referenceId == "DET-001"
+
+    # =========================================================================
+    # BEHAVIOR 2: StrictValidationMixin (Rejects unknown parameters)
+    # =========================================================================
+    with pytest.raises(ValueError, match="Extra fields not allowed in DetailData"):
+        DetailData(
+            name="Roof Section",
+            referenceId="DET-002",
+            hallucinated_param="invalid_field",
+        )
+
+    # =========================================================================
+    # BEHAVIOR 3: FrozenMixin (Immutable & Hashable)
+    # =========================================================================
+    # Mutating an attribute must raise a Pydantic ValidationError
+    with pytest.raises(ValidationError):
+        detail.name = "Changed Name"
+
+    # Must be hashable so it can be added to sets and used as dict keys
+    detail_set = {detail}
+    assert detail in detail_set
+
+    # =========================================================================
+    # BEHAVIOR 4: OmitDefaultsMixin (Default/None values excluded from dumps)
+    # =========================================================================
+    beam = BeamData(
+        begCoordinate=Coordinate2D(x=0.0, y=0.0),
+        endCoordinate=Coordinate2D(x=10.0, y=0.0),
+        zCoordinate=0.0,
+        # offset, slantAngle, arcAngle, etc. default to None
+    )
+    dumped = beam.model_dump()
+
+    assert "begCoordinate" in dumped
+    assert "offset" not in dumped
+    assert "slantAngle" not in dumped
+    assert "arcAngle" not in dumped
+
+
+def test_extra_allow_models_permit_arbitrary_keys_under_strict_mode(clean_models):
+    """
+    Verifies that models explicitly configured with extra='allow' (AddOnCommandParameters
+    and AddOnCommandResponse) continue to accept arbitrary keys, even when StrictValidationMixin
+    is globally enabled.
+    """
+    from multiconn_archicad.models.config import configure
+    from multiconn_archicad.models.mixins import StrictValidationMixin
+
+    # 1. Enable strict validation globally
+    configure(StrictValidationMixin)
+
+    # Import both standard models and the Add-On models
+    from multiconn_archicad.models.tapir.types import Coordinate2D
+    from multiconn_archicad.models.official.types import (
+        AddOnCommandParameters,
+        AddOnCommandResponse,
+    )
+
+    # =========================================================================
+    # 1. Verify that standard models are STILL strictly locked down
+    # =========================================================================
+    with pytest.raises(ValueError, match="Extra fields not allowed in Coordinate2D"):
+        Coordinate2D(x=1.0, y=2.0, forbidden_key="must_fail")
+
+    # =========================================================================
+    # 2. Verify AddOnCommandParameters allows arbitrary input keys
+    # =========================================================================
+    custom_params = AddOnCommandParameters.model_validate({
+        "customAddonKey": "customValue",
+        "nestedData": {"flag": True, "count": 42},
+        "targetStory": 1,
+    })
+
+    dumped_params = custom_params.model_dump()
+    assert dumped_params["customAddonKey"] == "customValue"
+    assert dumped_params["nestedData"] == {"flag": True, "count": 42}
+    assert dumped_params["targetStory"] == 1
+
+    # =========================================================================
+    # 3. Verify AddOnCommandResponse allows arbitrary response keys
+    # =========================================================================
+    custom_response = AddOnCommandResponse.model_validate({
+        "status": "OK",
+        "returnedGuids": ["uuid-1234", "uuid-5678"],
+        "executionTimeMs": 12.5,
+    })
+
+    dumped_response = custom_response.model_dump()
+    assert dumped_response["status"] == "OK"
+    assert dumped_response["returnedGuids"] == ["uuid-1234", "uuid-5678"]
+    assert dumped_response["executionTimeMs"] == 12.5

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "multiconn-archicad"
-version = "0.6.6"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "archicad" },


### PR DESCRIPTION
## Summary
Updates the base Pydantic models to default to forward-compatible parsing (`extra="ignore"`) while adding an opt-in `configure()` system. This allows consumers to inject mixins (e.g., strict validation, immutability, whitespace trimming) into `APIModel` before classes are compiled, without runtime overhead for default workflows.

---

## Key Changes

1. **Import-time Configuration (`config.py`)**:
   - Added `configure(*mixins)` to set base mixins for `APIModel`.
   - Added a module-level lock (`_Registry.locked`) that raises a loud `RuntimeError` if `configure()` is called after `base.py` has already been imported/compiled.

2. **Dynamic Base Model (`base.py`)**:
   - Changed default model config to `extra="ignore"` to prevent breaking on unknown API response fields.
   - Dynamically injects registered mixins into `APIModel` inheritance at import time.
   - Locks `_Registry` immediately upon `APIModel` definition.
   - Retains default overrides for `model_dump` and `model_dump_json` (`by_alias=True`, `exclude_none=True`).

3. **Built-in Mixins (`mixins.py`)**:
   - `StrictValidationMixin`: Forbids extra fields for commands/inputs. Includes context bypass (`context={"ignore_extra_keys": True}`) and respects models explicitly defined with `extra="allow"` (e.g., `AddOnCommandParameters`, `AddOnCommandResponse`).
   - `FrozenMixin`: Sets `model_config = ConfigDict(frozen=True)` for immutability and hashability.
   - `StripWhitespaceMixin`: Recursively trims leading/trailing whitespace from string fields before validation.
   - `OmitDefaultsMixin`: Sets `exclude_defaults=True` on serialization.

4. **Tests (`tests/test_model_config.py`)**:
   - Added tests for `configure()` lifecycle and late-call rejection.
   - Added isolation fixture (`clean_models`) and subprocess execution tests.
   - Added unit/integration tests for each mixin, multi-mixin composition, and `extra="allow"` passthrough under strict mode.

---

## Usage

```python
from multiconn_archicad.models.config import configure
from multiconn_archicad.models.mixins import StrictValidationMixin, FrozenMixin

# Must be called before importing any model classes
configure(StrictValidationMixin, FrozenMixin)

from multiconn_archicad.models.commands import ChangeWindowParameters
```