### PR TITLE
Refactor: convert basic types and ConnHeader to Pydantic V2

### DIFF
--- a/src/multiconn_archicad/__init__.py
+++ b/src/multiconn_archicad/__init__.py
@@ -19,7 +19,6 @@ from .basic_types import (
     ArchicadLocation,
     Port,
     APIResponseError,
-    FromAPIResponse,
 )
 from .standard_connection import StandardConnection
 from .core.core_commands import CoreCommands
@@ -51,7 +50,6 @@ __all__ = [
     "ConnHeader",
     "ArchiCadID",
     "APIResponseError",
-    "FromAPIResponse",
     "ProductInfo",
     "Port",
     "StandardConnection",

--- a/src/multiconn_archicad/actions/project_handler.py
+++ b/src/multiconn_archicad/actions/project_handler.py
@@ -40,13 +40,6 @@ class FindArchicad:
         return None
 
 
-@dataclass
-class ProjectParams:
-    conn_header: ValidatedHeader
-    teamwork_credentials: TeamworkCredentials | None
-    demo: bool
-
-
 @auto_decorate_methods(log_exceptions)
 class SwitchProject:
     def __init__(self, multi_conn: MultiConn):
@@ -55,7 +48,7 @@ class SwitchProject:
     def from_header(self, original_port: Port, new_header: ConnHeader) -> ConnHeader:
         if not isinstance(new_header.archicad_id, SoloProjectID):
             raise ProjectNotFoundError("Can only open solo projects in an open Archicad window")
-        return self._execute_action(original_port, os.fspath(new_header.archicad_id))
+        return self._execute_action(original_port, os.fspath(new_header.archicad_id.get_project_location()))
 
     def from_path(self, original_port: Port, new_path: str | os.PathLike[str]) -> ConnHeader:
         return self._execute_action(original_port, os.fspath(new_path))
@@ -86,6 +79,11 @@ class SwitchProject:
             except StandardAPIError:
                 pass
 
+@dataclass
+class ProjectParams:
+    conn_header: ConnHeader
+    teamwork_credentials: TeamworkCredentials | None
+    demo: bool
 
 @auto_decorate_methods(log_exceptions)
 class OpenProject:
@@ -94,19 +92,13 @@ class OpenProject:
         self.process: subprocess.Popen
 
     def from_header(self, conn_header: ConnHeader, demo: bool = False) -> Port | None:
-        if is_header_fully_initialized(conn_header):
-            project_params = ProjectParams(conn_header, None, demo)
-        else:
-            raise NotFullyInitializedError(f"Cannot open project from partially initializer header {conn_header}")
+        project_params = ProjectParams(conn_header, None, demo)
         return self._execute_action(project_params)
 
     def with_teamwork_credentials(
         self, conn_header: ConnHeader, teamwork_credentials: TeamworkCredentials, demo: bool = False
     ) -> Port | None:
-        if is_header_fully_initialized(conn_header):
-            project_params = ProjectParams(conn_header, teamwork_credentials, demo)
-        else:
-            raise NotFullyInitializedError(f"Cannot open project from partially initializer header {conn_header}")
+        project_params = ProjectParams(conn_header, teamwork_credentials, demo)
         return self._execute_action(project_params)
 
     def _execute_action(self, project_params: ProjectParams) -> Port | None:
@@ -121,6 +113,8 @@ class OpenProject:
         return port
 
     def _check_input(self, project_params: ProjectParams) -> None:
+        if not is_header_fully_initialized(project_params.conn_header):
+            raise NotFullyInitializedError(f"Cannot open project from partially initializer header {project_params.conn_header}")
         if isinstance(project_params.conn_header.archicad_id, TeamworkProjectID):
             if project_params.teamwork_credentials:
                 assert project_params.teamwork_credentials.password, "You must supply a valid password!"

--- a/src/multiconn_archicad/basic_types.py
+++ b/src/multiconn_archicad/basic_types.py
@@ -1,8 +1,22 @@
-from dataclasses import dataclass, asdict
-from typing import Self, Protocol, Type, Any, TypeVar, Union, ClassVar, cast
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Annotated, Any, ClassVar, Literal, Self, TypeVar, Union
 import re
 from urllib.parse import unquote
-from abc import ABC, abstractmethod
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    field_validator,
+    field_serializer,
+    model_validator,
+    Discriminator,
+    GetCoreSchemaHandler,
+)
+from pydantic_core import core_schema
 
 from multiconn_archicad.errors import APIErrorBase
 from multiconn_archicad.utilities.platform_utils import is_using_mac, double_quote, single_quote
@@ -11,154 +25,134 @@ JsonType = Union[str, int, float, bool, None, list["JsonType"], dict[str, "JsonT
 
 
 class Port(int):
-    def __new__(cls, value):
-        if not (19723 <= value < 19744):
-            raise ValueError(f"Port value must be between 19723 and 19744, got {value}.")
-        return int.__new__(cls, value)
+    """Port constraint for Archicad JSON API (19723 <= port < 19744)."""
 
+    MIN_PORT: ClassVar[int] = 19723
+    MAX_PORT: ClassVar[int] = 19744
 
-class FromAPIResponse(Protocol):
+    def __new__(cls, value: int | str) -> Self:
+        int_val = int(value)
+        if not (cls.MIN_PORT <= int_val < cls.MAX_PORT):
+            raise ValueError(f"Port value must be between {cls.MIN_PORT} and {cls.MAX_PORT}, got {int_val}.")
+        return super().__new__(cls, int_val)
+
     @classmethod
-    def from_api_response(cls, response: dict) -> Self: ...
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.chain_schema([
+            core_schema.int_schema(ge=cls.MIN_PORT, lt=cls.MAX_PORT),
+            core_schema.no_info_plain_validator_function(cls),
+        ])
 
 
-@dataclass
-class BaseModel:
-    """Base class providing common functionality for data models"""
+class HeaderInfoBase(BaseModel):
+    """Base class providing common configuration and backward-compatible helper methods."""
 
-    def to_dict(self) -> dict[str, JsonType]:
-        """Convert the instance to a dictionary suitable for JSON serialization."""
-        return asdict(self)
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump()
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Self:
-        """Create an instance from a dictionary."""
-        return cls(**data)
-
-
-@dataclass
-class ProductInfo(BaseModel):
-    version: int
-    build: int
-    lang: str
+        return cls.model_validate(data)
 
     @classmethod
-    def from_api_response(cls, response: dict) -> Self:
-        return cls(
-            response["version"],
-            response["buildNumber"],
-            response["languageCode"],
-        )
+    def from_api_response(cls, response: dict[str, Any]) -> Self:
+        return cls.model_validate(response)
 
 
-@dataclass
-class ArchicadLocation(BaseModel):
+class ProductInfo(HeaderInfoBase):
+    version: int
+    build: int = Field(alias="buildNumber")
+    lang: str = Field(alias="languageCode")
+
+
+class ArchicadLocation(HeaderInfoBase):
     archicadLocation: str
 
+    @field_validator("archicadLocation", mode="after")
     @classmethod
-    def from_api_response(cls, response: dict) -> Self:
-        location = response["archicadLocation"]
-        return cls(f"{location}/Contents/MacOS/ARCHICAD" if is_using_mac() else location)
+    def _normalize_mac_path(cls, v: str) -> str:
+        if is_using_mac() and not v.endswith("/Contents/MacOS/ARCHICAD"):
+            return f"{v}/Contents/MacOS/ARCHICAD"
+        return v
 
 
-@dataclass
-class APIResponseError(BaseModel):
-    code: int | None
+class APIResponseError(HeaderInfoBase):
+    code: int | None = None
     message: str
 
     @classmethod
-    def from_exception(cls, response: APIErrorBase) -> Self:
+    def from_exception(cls, exc: APIErrorBase | Exception) -> Self:
         return cls(
-            code=response.code,
-            message=response.message,
-        )
-
-    @classmethod
-    def from_api_response(cls, response: dict) -> Self:
-        return cls(
-            code=response["code"],
-            message=response["message"],
+            code=getattr(exc, "code", None),
+            message=getattr(exc, "message", str(exc)),
         )
 
 
-@dataclass
 class PendingResponse(APIResponseError):
     code: int | None = None
     message: str = "Identifying..."
 
 
-@dataclass
-class TeamworkCredentials(BaseModel):
+class TeamworkCredentials(HeaderInfoBase):
     username: str
-    password: str | None
+    password: SecretStr | None = None
 
-    def __repr__(self) -> str:
-        attrs = vars(self).copy()
-        attrs["password"] = "*" * len(self.password) if self.password else None
-        str_repr = ", ".join(f"{k}={v!r}" for k, v in attrs.items())
-        return f"{self.__class__.__name__}({str_repr})"
-
-    def __str__(self) -> str:
-        return self.__repr__()
-
-    def to_dict(self) -> dict[str, JsonType]:
-        return self.__dict__.copy() | {"password": None}
+    @field_serializer("password", when_used="always")
+    def _serialize_password(self, password: SecretStr | None) -> None:
+        return None
 
 
-class ArchiCadID(ABC):
-    _ID_type_registry: ClassVar[dict[str, Type[Self]]] = {}
+def get_project_type(v: Any) -> str | None:
+    """Extracts discriminator tag from serialized dict or raw Tapir API response."""
+    if isinstance(v, dict):
+        if "project_type" in v:
+            return v["project_type"]
+        if "isUntitled" in v and "isTeamwork" in v:
+            if v["isUntitled"]:
+                return "untitled"
+            if v["isTeamwork"]:
+                return "teamwork"
+            return "solo"
+        return None
+    return getattr(v, "project_type", None)
+
+
+class ArchiCadID(HeaderInfoBase, ABC):
     projectName: str = "Untitled"
 
-    @classmethod
-    def register_subclass(cls, subclass: Type[Self]) -> Type[Self]:
-        cls._ID_type_registry[subclass.__name__] = subclass
-        return subclass
-
-    @classmethod
-    def from_api_response(cls, response: dict) -> "ArchiCadID":
-        if response["isUntitled"]:
-            return cls._ID_type_registry["UntitledProjectID"]()
-        elif not response["isTeamwork"]:
-            solo_project_id_cls = cast(Type[SoloProjectID], cls._ID_type_registry["SoloProjectID"])
-            return solo_project_id_cls(
-                projectPath=response["projectPath"],
-                projectName=response["projectName"],
-            )
-        else:
-            teamwork_project_id_cls = cast(Type[TeamworkProjectID], cls._ID_type_registry["TeamworkProjectID"])
-            return teamwork_project_id_cls.from_project_location(
-                project_location=response["projectLocation"],
-                project_name=response["projectName"],
-            )
-
     @abstractmethod
-    def to_dict(self) -> dict[str, JsonType]: ...
+    def get_project_location(self, teamwork_credentials: TeamworkCredentials | None = None) -> str | None: ...
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Self:
-        for id_type in cls._ID_type_registry.values():
-            try:
-                return id_type.from_dict(data)
-            except (KeyError, AttributeError, TypeError):
-                pass
-        raise AttributeError(f"can not instantiate ArchiCadID from {data}")
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        if source_type.__name__ == "ArchiCadID" and "UntitledProjectID" in globals():
+            return core_schema.tagged_union_schema(
+                choices={
+                    "untitled": handler.generate_schema(globals()["UntitledProjectID"]),
+                    "solo": handler.generate_schema(globals()["SoloProjectID"]),
+                    "teamwork": handler.generate_schema(globals()["TeamworkProjectID"]),
+                },
+                discriminator=get_project_type,
+            )
+        return handler(source_type)
 
-    @abstractmethod
-    def get_project_location(self, _: TeamworkCredentials | None = None) -> str | None: ...
 
-
-@ArchiCadID.register_subclass
-@dataclass
-class UntitledProjectID(BaseModel, ArchiCadID):
+class UntitledProjectID(ArchiCadID):
+    project_type: Literal["untitled"] = "untitled"
     projectName: str = "Untitled"
 
     def get_project_location(self, _: TeamworkCredentials | None = None) -> None:
         return None
 
 
-@ArchiCadID.register_subclass
-@dataclass
-class SoloProjectID(BaseModel, ArchiCadID):
+class SoloProjectID(ArchiCadID):
+    project_type: Literal["solo"] = "solo"
     projectPath: str
     projectName: str
 
@@ -169,49 +163,59 @@ class SoloProjectID(BaseModel, ArchiCadID):
         return self.projectPath
 
 
-@ArchiCadID.register_subclass
-@dataclass
-class TeamworkProjectID(BaseModel, ArchiCadID):
+class TeamworkProjectID(ArchiCadID):
+    project_type: Literal["teamwork"] = "teamwork"
     projectPath: str
     serverAddress: str
     teamworkCredentials: TeamworkCredentials
     projectName: str
 
+    @model_validator(mode="before")
+    @classmethod
+    def _parse_project_location(cls, data: Any) -> Any:
+        """Parses raw projectLocation URL into address, path, and credentials."""
+        if isinstance(data, dict) and "projectLocation" in data:
+            match = cls.match_project_location(data.pop("projectLocation"))
+            data.setdefault("serverAddress", match.group("serverAddress"))
+            data.setdefault("projectPath", match.group("projectPath"))
+            data.setdefault(
+                "teamworkCredentials",
+                TeamworkCredentials(
+                    username=match.group("username"),
+                    password=match.group("password"),
+                ),
+            )
+        return data
+
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, TeamworkProjectID):
-            if (
+            return (
                 self.projectPath == other.projectPath
                 and self.serverAddress == other.serverAddress
                 and self.projectName == other.projectName
-            ):
-                return True
+            )
         return False
 
     def get_project_location(self, teamwork_credentials: TeamworkCredentials | None = None) -> str:
-        teamwork_credentials = teamwork_credentials if teamwork_credentials else self.teamworkCredentials
-        if not teamwork_credentials.password:
+        creds = teamwork_credentials or self.teamworkCredentials
+        if not creds.password:
             raise ValueError("Missing password in teamwork credentials.")
-        else:
-            return (
-                f"teamwork://{single_quote(teamwork_credentials.username)}:{single_quote(teamwork_credentials.password)}@"
-                f"{double_quote(self.serverAddress)}/{double_quote(self.projectPath)}"
-            )
+        raw_password = (
+            creds.password.get_secret_value()
+            if isinstance(creds.password, SecretStr)
+            else creds.password
+        )
+        return (
+            f"teamwork://{single_quote(creds.username)}:{single_quote(raw_password)}@"
+            f"{double_quote(self.serverAddress)}/{double_quote(self.projectPath)}"
+        )
 
     @classmethod
     def from_project_location(cls, project_location: str, project_name: str) -> Self:
-        match = cls.match_project_location(project_location)
-        return cls(
-            serverAddress=match.group("serverAddress"),
-            projectPath=match.group("projectPath"),
-            teamworkCredentials=TeamworkCredentials(
-                username=match.group("username"),
-                password=match.group("password"),
-            ),
-            projectName=project_name,
-        )
+        return cls.model_validate({"projectLocation": project_location, "projectName": project_name})
 
     @staticmethod
-    def match_project_location(project_location: str) -> re.Match:
+    def match_project_location(project_location: str) -> re.Match[str]:
         project_location = unquote(unquote(project_location))
         pattern = re.compile(
             r"teamwork://(?P<username>[^:]+):(?P<password>[^@]+)@(?P<serverAddress>https?://[^/]+)/(?P<projectPath>.*)?"
@@ -219,23 +223,18 @@ class TeamworkProjectID(BaseModel, ArchiCadID):
         match = pattern.match(project_location)
         if not match:
             raise ValueError(
-                f"Could not recognize projectLocation format:/n({project_location})/n Please, contact developer"
+                f"Could not recognize projectLocation format:\n({project_location})\nPlease, contact developer"
             )
         return match
 
-    def to_dict(self) -> dict[str, JsonType]:
-        return asdict(self) | {"teamworkCredentials": self.teamworkCredentials.to_dict()}
 
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Self:
-        return cls(**data | {"teamworkCredentials": TeamworkCredentials.from_dict(data["teamworkCredentials"])})
+ArchiCadID.model_rebuild(force=True)
+T = TypeVar("T", bound=HeaderInfoBase)
 
 
-T = TypeVar("T", bound=FromAPIResponse)
-
-
-async def create_object_or_error_from_response(result: dict, class_to_create: Type[T]) -> T | APIResponseError:
-    if result["succeeded"]:
-        return class_to_create.from_api_response(result)
-    else:
-        return APIResponseError.from_api_response(result)
+def create_object_or_error_from_response(
+    result: dict[str, Any], class_to_create: type[T]
+) -> T | APIResponseError:
+    if result.get("succeeded", True):
+        return class_to_create.model_validate(result)
+    return APIResponseError.model_validate(result)

--- a/src/multiconn_archicad/basic_types.py
+++ b/src/multiconn_archicad/basic_types.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Annotated, Any, ClassVar, Literal, Self, TypeVar, Union
+from typing import Any, ClassVar, Literal, Self, Union
 import re
 from urllib.parse import unquote
 
 from pydantic import (
     BaseModel,
     ConfigDict,
-    Field,
     SecretStr,
     field_validator,
     field_serializer,
     model_validator,
-    Discriminator,
     GetCoreSchemaHandler,
 )
 from pydantic_core import core_schema
@@ -65,8 +63,8 @@ class HeaderInfoBase(BaseModel):
 
 class ProductInfo(HeaderInfoBase):
     version: int
-    build: int = Field(alias="buildNumber")
-    lang: str = Field(alias="languageCode")
+    buildNumber: int
+    languageCode: str
 
 
 class ArchicadLocation(HeaderInfoBase):
@@ -175,6 +173,7 @@ class TeamworkProjectID(ArchiCadID):
     def _parse_project_location(cls, data: Any) -> Any:
         """Parses raw projectLocation URL into address, path, and credentials."""
         if isinstance(data, dict) and "projectLocation" in data:
+            data = dict(data)
             match = cls.match_project_location(data.pop("projectLocation"))
             data.setdefault("serverAddress", match.group("serverAddress"))
             data.setdefault("projectPath", match.group("projectPath"))
@@ -229,12 +228,3 @@ class TeamworkProjectID(ArchiCadID):
 
 
 ArchiCadID.model_rebuild(force=True)
-T = TypeVar("T", bound=HeaderInfoBase)
-
-
-def create_object_or_error_from_response(
-    result: dict[str, Any], class_to_create: type[T]
-) -> T | APIResponseError:
-    if result.get("succeeded", True):
-        return class_to_create.model_validate(result)
-    return APIResponseError.model_validate(result)

--- a/src/multiconn_archicad/conn_header.py
+++ b/src/multiconn_archicad/conn_header.py
@@ -6,6 +6,9 @@ from typing import Self, Any, TypeGuard
 from pprint import pformat
 import logging
 
+from pydantic import GetCoreSchemaHandler, ValidationError
+from pydantic_core import core_schema
+
 from multiconn_archicad.core.core_commands import CoreCommands
 from multiconn_archicad.basic_types import (
     ArchiCadID,
@@ -38,10 +41,10 @@ class Status(Enum):
 
 
 class ConnHeader:
-    def __init__(self, port: Port, initialize: bool = True, ui_mode: bool = False):
+    def __init__(self, port: Port | None = None, initialize: bool = True, ui_mode: bool = False):
 
         self._port: Port | None = port
-        self._status: Status = Status.PENDING
+        self._status: Status = Status.PENDING if port else Status.UNASSIGNED
         self._ui_mode: bool = ui_mode
         self._is_cancelled: bool = False
 
@@ -122,22 +125,56 @@ class ConnHeader:
         self._sync_if_needed()
         return self._archicad_location
 
-    def to_dict(self) -> dict[str, Any]:
+    def model_dump(self) -> dict[str, Any]:
+        """Serialize connection header. Requires the header to be fully initialized."""
+        if not is_header_fully_initialized(self):
+            raise ValueError(
+                f"Cannot serialize ConnHeader on port {self.port}: Header is not fully initialized "
+                f"(status={self._status.value})."
+            )
         return {
-            "port": self.port,
-            "productInfo": self.product_info.to_dict(),
-            "archicadId": self.archicad_id.to_dict(),
-            "archicadLocation": self.archicad_location.to_dict(),
+            "productInfo": self._product_info.model_dump(),
+            "archicadId": self._archicad_id.model_dump(),
+            "archicadLocation": self._archicad_location.model_dump(),
         }
 
+    to_dict = model_dump
+
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Self:
-        instance = cls(initialize=False, port=Port(data["port"]))
-        instance._status = Status.UNASSIGNED
-        instance._product_info = ProductInfo.from_dict(data["productInfo"])
-        instance._archicad_id = ArchiCadID.from_dict(data["archicadId"])
-        instance._archicad_location = ArchicadLocation.from_dict(data["archicadLocation"])
+    def model_validate(cls, data: Any) -> Self:
+        """Validate and construct a ConnHeader from serialized snapshot data."""
+        if isinstance(data, cls):
+            return data
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected {cls.__name__} instance or dict, got {type(data).__name__}")
+
+        instance = cls(initialize=False)
+        instance._product_info = ProductInfo.model_validate(data["productInfo"])
+        instance._archicad_id = ArchiCadID.model_validate(data["archicadId"])
+        instance._archicad_location = ArchicadLocation.model_validate(data["archicadLocation"])
         return instance
+
+    from_dict = model_validate
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        """Enables Pydantic V2 to serialize/deserialize ConnHeader controllers."""
+
+        return core_schema.json_or_python_schema(
+            json_schema=core_schema.chain_schema([
+                core_schema.dict_schema(),
+                core_schema.no_info_plain_validator_function(cls.model_validate),
+            ]),
+            python_schema=core_schema.chain_schema([
+                core_schema.no_info_plain_validator_function(cls.model_validate),
+                core_schema.is_instance_schema(cls),
+            ]),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                lambda instance: instance.model_dump(),
+                when_used="always",
+            ),
+        )
+
 
     def __eq__(self, other: Any) -> bool:
         if self is other:
@@ -268,29 +305,29 @@ class ConnHeader:
     def get_product_info(self, timeout: float) -> ProductInfo | APIResponseError:
         try:
             result = self.core.post_command(command="API.GetProductInfo", timeout=timeout)
-            return ProductInfo.from_api_response(result)
+            return ProductInfo.model_validate(result)
         except (RequestError, ArchicadAPIError) as e:
             return APIResponseError.from_exception(e)
-        except (KeyError, TypeError) as e:
-            return APIResponseError(code=None, message=f"Malformed API response: missing key {e}")
+        except (KeyError, TypeError, ValidationError) as e:
+            return APIResponseError(code=None, message=f"Malformed API response: {e}")
 
     def get_archicad_id(self, timeout: float) -> ArchiCadID | APIResponseError:
         try:
             result = self.core.post_tapir_command(command="GetProjectInfo", timeout=timeout)
-            return ArchiCadID.from_api_response(result)
+            return ArchiCadID.model_validate(result)
         except (RequestError, ArchicadAPIError) as e:
             return APIResponseError.from_exception(e)
-        except (KeyError, TypeError) as e:
-            return APIResponseError(code=None, message=f"Malformed API response: missing key {e}")
+        except (KeyError, TypeError, ValidationError) as e:
+            return APIResponseError(code=None, message=f"Malformed API response: {e}")
 
     def get_archicad_location(self, timeout: float) -> ArchicadLocation | APIResponseError:
         try:
             result = self.core.post_tapir_command(command="GetArchicadLocation", timeout=timeout)
-            return ArchicadLocation.from_api_response(result)
+            return ArchicadLocation.model_validate(result)
         except (RequestError, ArchicadAPIError) as e:
             return APIResponseError.from_exception(e)
-        except (KeyError, TypeError) as e:
-            return APIResponseError(code=None, message=f"Malformed API response: missing key {e}")
+        except (KeyError, TypeError, ValidationError) as e:
+            return APIResponseError(code=None, message=f"Malformed API response: {e}")
 
 
 class ValidatedHeader(ConnHeader):

--- a/src/multiconn_archicad/conn_header.py
+++ b/src/multiconn_archicad/conn_header.py
@@ -53,9 +53,9 @@ class ConnHeader:
         self._unpacked_future: Future | None = None
         self._auto_connect: bool = False
 
-        self._core: CoreCommands | None = CoreCommands(port)
-        self._standard: StandardConnection | None = StandardConnection(port)
-        self._unified: UnifiedApi | None = UnifiedApi(self.core)
+        self._core: CoreCommands | None = CoreCommands(port) if port else None
+        self._standard: StandardConnection | None = StandardConnection(port) if port else None
+        self._unified: UnifiedApi | None = UnifiedApi(self.core) if self._core else None
 
         self._product_info: ProductInfo | APIResponseError = PendingResponse()
         self._archicad_id: ArchiCadID | APIResponseError  = PendingResponse()

--- a/src/multiconn_archicad/standard_connection.py
+++ b/src/multiconn_archicad/standard_connection.py
@@ -25,7 +25,7 @@ class StandardConnection:
         return f"{self.__class__.__name__}(_request={self._request.full_url})"
 
     def connect(self, product_info: ProductInfo) -> None:
-        v = _Versioning(product_info.version, product_info.build, self._request)
+        v = _Versioning(product_info.version, product_info.buildNumber, self._request)
         self.commands = v.commands
         self.types = v.types
         self.utilities = v.utilities

--- a/tests/integration/test_project_management.py
+++ b/tests/integration/test_project_management.py
@@ -107,9 +107,8 @@ def test_open_project_calls_dependencies_correctly(
     # Prepare a header to open
     header_to_open = ConnHeader.from_dict(
         {
-            "port": 19723,  # This port is just a placeholder in the saved data
-            "productInfo": {"version": 27, "build": 3001, "lang": "INT"},
-            "archicadId": {"projectPath": "C:\\path\\to\\project.pln", "projectName": "My Test Project.pln"},
+            "productInfo": {"version": 27, "buildNumber": 3001, "languageCode": "INT"},
+            "archicadId": {"project_type": "solo", "projectPath": "C:\\path\\to\\project.pln", "projectName": "My Test Project.pln"},
             "archicadLocation": {"archicadLocation": "C:\\Archicad\\ARCHICAD.exe"},
         }
     )

--- a/tests/unit/test_basic_types.py
+++ b/tests/unit/test_basic_types.py
@@ -70,30 +70,30 @@ def test_product_info_from_api_response():
     api_response = {"version": 26, "buildNumber": 3001, "languageCode": "en"}
     product_info = ProductInfo.from_api_response(api_response)
     assert product_info.version == 26
-    assert product_info.build == 3001
-    assert product_info.lang == "en"
+    assert product_info.buildNumber == 3001
+    assert product_info.languageCode == "en"
 
 
 def test_product_info_to_dict():
-    product_info = ProductInfo(version=26, build=3001, lang="en")
-    expected_dict = {"version": 26, "build": 3001, "lang": "en"}
+    product_info = ProductInfo(version=26, buildNumber=3001, languageCode="en")
+    expected_dict = {"version": 26, "buildNumber": 3001, "languageCode": "en"}
     assert product_info.to_dict() == expected_dict
     assert product_info.model_dump() == expected_dict
 
 
 def test_product_info_from_dict():
-    data_dict = {"version": 26, "build": 3001, "lang": "en"}
+    data_dict = {"version": 26, "buildNumber": 3001, "languageCode": "en"}
     product_info = ProductInfo.from_dict(data_dict)
     assert product_info.version == 26
-    assert product_info.build == 3001
-    assert product_info.lang == "en"
+    assert product_info.buildNumber == 3001
+    assert product_info.languageCode == "en"
 
 
 def test_product_info_alias_construction():
     product_info = ProductInfo(version=27, buildNumber=4000, languageCode="INT")
     assert product_info.version == 27
-    assert product_info.build == 4000
-    assert product_info.lang == "INT"
+    assert product_info.buildNumber == 4000
+    assert product_info.languageCode == "INT"
 
 
 # -------------------------------------------------------------------------

--- a/tests/unit/test_basic_types.py
+++ b/tests/unit/test_basic_types.py
@@ -362,24 +362,45 @@ def test_teamwork_project_id_from_dict():
 # -------------------------------------------------------------------------
 # Tests for ArchicadLocation class
 # -------------------------------------------------------------------------
-@pytest.mark.parametrize("is_mac,expected_suffix", [(True, "/Contents/MacOS/ARCHICAD"), (False, "")])
-def test_archicad_location_from_api_response(is_mac, expected_suffix):
+@pytest.mark.parametrize("is_mac,expected_path", [
+    (True, "/Applications/ARCHICAD/Contents/MacOS/ARCHICAD"),
+    (False, "/Applications/ARCHICAD"),
+])
+def test_archicad_location_from_api_response(is_mac, expected_path):
     with patch("multiconn_archicad.basic_types.is_using_mac", return_value=is_mac):
         api_response = {"archicadLocation": "/Applications/ARCHICAD"}
         location = ArchicadLocation.from_api_response(api_response)
-        assert location.archicadLocation == f"/Applications/ARCHICAD{expected_suffix}"
+        assert location.archicadLocation == expected_path
 
 
-def test_archicad_location_to_dict():
-    location = ArchicadLocation(archicadLocation="/path/to/archicad")
-    expected_dict = {"archicadLocation": "/path/to/archicad"}
-    assert location.to_dict() == expected_dict
+@pytest.mark.parametrize("is_mac,expected_path", [
+    (True, "/path/to/archicad/Contents/MacOS/ARCHICAD"),
+    (False, "/path/to/archicad"),
+])
+def test_archicad_location_to_dict(is_mac, expected_path):
+    with patch("multiconn_archicad.basic_types.is_using_mac", return_value=is_mac):
+        location = ArchicadLocation(archicadLocation="/path/to/archicad")
+        assert location.to_dict() == {"archicadLocation": expected_path}
+        assert location.model_dump() == {"archicadLocation": expected_path}
 
 
-def test_archicad_location_from_dict():
-    data_dict = {"archicadLocation": "/path/to/archicad"}
-    location = ArchicadLocation.from_dict(data_dict)
-    assert location.archicadLocation == "/path/to/archicad"
+@pytest.mark.parametrize("is_mac,expected_path", [
+    (True, "/path/to/archicad/Contents/MacOS/ARCHICAD"),
+    (False, "/path/to/archicad"),
+])
+def test_archicad_location_from_dict(is_mac, expected_path):
+    with patch("multiconn_archicad.basic_types.is_using_mac", return_value=is_mac):
+        data_dict = {"archicadLocation": "/path/to/archicad"}
+        location = ArchicadLocation.from_dict(data_dict)
+        assert location.archicadLocation == expected_path
+
+
+def test_archicad_location_mac_already_normalized():
+    """Ensure it doesn't double-append /Contents/MacOS/ARCHICAD on Mac."""
+    with patch("multiconn_archicad.basic_types.is_using_mac", return_value=True):
+        path = "/Applications/ARCHICAD/Contents/MacOS/ARCHICAD"
+        location = ArchicadLocation(archicadLocation=path)
+        assert location.archicadLocation == path
 
 
 # -------------------------------------------------------------------------

--- a/tests/unit/test_basic_types.py
+++ b/tests/unit/test_basic_types.py
@@ -1,35 +1,28 @@
+import os
 import pytest
-from unittest.mock import patch, MagicMock
-from dataclasses import dataclass, asdict
+from unittest.mock import patch
+from pydantic import ValidationError
 
-from multiconn_archicad import (
+from multiconn_archicad.basic_types import (
     ArchiCadID,
     UntitledProjectID,
-    TeamworkCredentials,
     SoloProjectID,
+    TeamworkProjectID,
+    TeamworkCredentials,
     ProductInfo,
     Port,
-    TeamworkProjectID,
     APIResponseError,
+    PendingResponse,
     ArchicadLocation,
 )
+from multiconn_archicad.errors import APIErrorBase
 
 pytestmark = pytest.mark.unit
 
-# Setup for common fixtures
-@pytest.fixture
-def reset_archicad_id_registry():
-    """Reset the ArchiCadID registry before and after each test."""
-    original_registry = ArchiCadID._ID_type_registry.copy()
-    ArchiCadID._ID_type_registry = {
-        "UntitledProjectID": UntitledProjectID,
-        "SoloProjectID": SoloProjectID,
-        "TeamworkProjectID": TeamworkProjectID,
-    }
-    yield
-    ArchiCadID._ID_type_registry = original_registry
 
-
+# -------------------------------------------------------------------------
+# Fixtures
+# -------------------------------------------------------------------------
 @pytest.fixture
 def teamwork_credentials():
     """Create sample TeamworkCredentials."""
@@ -47,9 +40,9 @@ def teamwork_project_id(teamwork_credentials):
     )
 
 
+# -------------------------------------------------------------------------
 # Tests for Port class
-
-
+# -------------------------------------------------------------------------
 def test_valid_port():
     valid_port = 19730
     port = Port(valid_port)
@@ -70,9 +63,9 @@ def test_invalid_port_too_high():
         Port(invalid_port)
 
 
+# -------------------------------------------------------------------------
 # Tests for ProductInfo class
-
-
+# -------------------------------------------------------------------------
 def test_product_info_from_api_response():
     api_response = {"version": 26, "buildNumber": 3001, "languageCode": "en"}
     product_info = ProductInfo.from_api_response(api_response)
@@ -85,6 +78,7 @@ def test_product_info_to_dict():
     product_info = ProductInfo(version=26, build=3001, lang="en")
     expected_dict = {"version": 26, "build": 3001, "lang": "en"}
     assert product_info.to_dict() == expected_dict
+    assert product_info.model_dump() == expected_dict
 
 
 def test_product_info_from_dict():
@@ -95,15 +89,22 @@ def test_product_info_from_dict():
     assert product_info.lang == "en"
 
 
+def test_product_info_alias_construction():
+    product_info = ProductInfo(version=27, buildNumber=4000, languageCode="INT")
+    assert product_info.version == 27
+    assert product_info.build == 4000
+    assert product_info.lang == "INT"
+
+
+# -------------------------------------------------------------------------
 # Tests for TeamworkCredentials class
-
-
+# -------------------------------------------------------------------------
 def test_teamwork_credentials_repr_with_password():
     credentials = TeamworkCredentials(username="user", password="secret")
     repr_str = repr(credentials)
     assert "username='user'" in repr_str
-    assert "password='******'" in repr_str
-    assert "password='secret'" not in repr_str
+    assert "secret" not in repr_str
+    assert "**********" in repr_str
 
 
 def test_teamwork_credentials_repr_without_password():
@@ -117,21 +118,24 @@ def test_teamwork_credentials_to_dict():
     credentials = TeamworkCredentials(username="user", password="secret")
     expected_dict = {"username": "user", "password": None}
     assert credentials.to_dict() == expected_dict
+    assert credentials.model_dump() == expected_dict
 
 
 def test_teamwork_credentials_from_dict():
     data_dict = {"username": "user", "password": "secret"}
     credentials = TeamworkCredentials.from_dict(data_dict)
     assert credentials.username == "user"
-    assert credentials.password == "secret"
+    assert credentials.password is not None
+    assert credentials.password.get_secret_value() == "secret"
 
 
+# -------------------------------------------------------------------------
 # Tests for UntitledProjectID class
-
-
+# -------------------------------------------------------------------------
 def test_untitled_project_id_default_project_name():
     project_id = UntitledProjectID()
     assert project_id.projectName == "Untitled"
+    assert project_id.project_type == "untitled"
 
 
 def test_untitled_project_id_get_project_location():
@@ -141,7 +145,7 @@ def test_untitled_project_id_get_project_location():
 
 def test_untitled_project_id_to_dict():
     project_id = UntitledProjectID()
-    expected_dict = {"projectName": "Untitled"}
+    expected_dict = {"project_type": "untitled", "projectName": "Untitled"}
     assert project_id.to_dict() == expected_dict
 
 
@@ -149,15 +153,17 @@ def test_untitled_project_id_from_dict():
     data_dict = {"projectName": "Untitled"}
     project_id = UntitledProjectID.from_dict(data_dict)
     assert project_id.projectName == "Untitled"
+    assert project_id.project_type == "untitled"
 
 
+# -------------------------------------------------------------------------
 # Tests for SoloProjectID class
-
-
+# -------------------------------------------------------------------------
 def test_solo_project_id_constructor():
     project_id = SoloProjectID(projectPath="C:\\python\\tests\\TestProject03.pla", projectName="MyProject")
     assert project_id.projectPath == "C:\\python\\tests\\TestProject03.pla"
     assert project_id.projectName == "MyProject"
+    assert project_id.project_type == "solo"
 
 
 def test_solo_project_id_get_project_location():
@@ -165,9 +171,18 @@ def test_solo_project_id_get_project_location():
     assert project_id.get_project_location() == "C:\\python\\tests\\TestProject03.pla"
 
 
+def test_solo_project_id_fspath():
+    project_id = SoloProjectID(projectPath="C:\\python\\tests\\TestProject03.pla", projectName="MyProject")
+    assert os.fspath(project_id) == "C:\\python\\tests\\TestProject03.pla"
+
+
 def test_solo_project_id_to_dict():
     project_id = SoloProjectID(projectPath="C:\\python\\tests\\TestProject03.pla", projectName="MyProject")
-    expected_dict = {"projectPath": "C:\\python\\tests\\TestProject03.pla", "projectName": "MyProject"}
+    expected_dict = {
+        "project_type": "solo",
+        "projectPath": "C:\\python\\tests\\TestProject03.pla",
+        "projectName": "MyProject",
+    }
     assert project_id.to_dict() == expected_dict
 
 
@@ -176,11 +191,12 @@ def test_solo_project_id_from_dict():
     project_id = SoloProjectID.from_dict(data_dict)
     assert project_id.projectPath == "C:\\python\\tests\\TestProject03.pla"
     assert project_id.projectName == "MyProject"
+    assert project_id.project_type == "solo"
 
 
+# -------------------------------------------------------------------------
 # Tests for TeamworkProjectID class
-
-
+# -------------------------------------------------------------------------
 def test_teamwork_project_id_constructor(teamwork_credentials):
     project_id = TeamworkProjectID(
         projectPath="projects/myproject",
@@ -192,6 +208,7 @@ def test_teamwork_project_id_constructor(teamwork_credentials):
     assert project_id.serverAddress == "https://teamwork.example.com"
     assert project_id.teamworkCredentials == teamwork_credentials
     assert project_id.projectName == "MyTeamworkProject"
+    assert project_id.project_type == "teamwork"
 
 
 def test_teamwork_project_id_eq_same_project(teamwork_credentials):
@@ -226,24 +243,20 @@ def test_teamwork_project_id_eq_different_project(teamwork_credentials, differen
         projectName="MyTeamworkProject",
     )
 
-    # Create a dictionary with the base values
     project_id2_args = {
         "projectPath": "projects/myproject",
         "serverAddress": "https://teamwork.example.com",
         "teamworkCredentials": teamwork_credentials,
         "projectName": "MyTeamworkProject",
     }
-    # Update the attribute that should be different
     project_id2_args[different_attr] = different_value
 
     project_id2 = TeamworkProjectID(**project_id2_args)
-
     assert project_id1 != project_id2
 
 
 def test_teamwork_project_id_eq_different_type(teamwork_project_id):
-    other_object = "not a TeamworkProjectID"
-    assert teamwork_project_id != other_object
+    assert teamwork_project_id != "not a TeamworkProjectID"
 
 
 def test_teamwork_project_id_get_project_location(teamwork_project_id):
@@ -292,28 +305,16 @@ def test_teamwork_project_id_get_project_location_without_password():
 
 
 def test_teamwork_project_id_from_project_location():
-    with patch(
-        "multiconn_archicad.basic_types.TeamworkProjectID.match_project_location"
-    ) as mock_match_project_location:
-        mock_match = MagicMock()
-        mock_match.group.side_effect = lambda key: {
-            "serverAddress": "https://teamwork.example.com",
-            "projectPath": "projects/myproject",
-            "username": "user",
-            "password": "secret",
-        }[key]
-        mock_match_project_location.return_value = mock_match
+    project_id = TeamworkProjectID.from_project_location(
+        project_location="teamwork://user:secret@https://teamwork.example.com/projects/myproject",
+        project_name="MyTeamworkProject",
+    )
 
-        project_id = TeamworkProjectID.from_project_location(
-            project_location="teamwork://user:secret@https://teamwork.example.com/projects/myproject",
-            project_name="MyTeamworkProject",
-        )
-
-        assert project_id.serverAddress == "https://teamwork.example.com"
-        assert project_id.projectPath == "projects/myproject"
-        assert project_id.projectName == "MyTeamworkProject"
-        assert project_id.teamworkCredentials.username == "user"
-        assert project_id.teamworkCredentials.password == "secret"
+    assert project_id.serverAddress == "https://teamwork.example.com"
+    assert project_id.projectPath == "projects/myproject"
+    assert project_id.projectName == "MyTeamworkProject"
+    assert project_id.teamworkCredentials.username == "user"
+    assert project_id.teamworkCredentials.password.get_secret_value() == "secret"
 
 
 def test_teamwork_project_id_match_project_location_valid():
@@ -327,14 +328,13 @@ def test_teamwork_project_id_match_project_location_valid():
 
 
 def test_teamwork_project_id_match_project_location_invalid():
-    invalid_location = "invalid://format"
-
     with pytest.raises(ValueError, match="Could not recognize projectLocation format"):
-        TeamworkProjectID.match_project_location(invalid_location)
+        TeamworkProjectID.match_project_location("invalid://format")
 
 
 def test_teamwork_project_id_to_dict(teamwork_project_id):
     expected_dict = {
+        "project_type": "teamwork",
         "projectPath": "projects/myproject",
         "serverAddress": "https://teamwork.example.com",
         "teamworkCredentials": {"username": "user", "password": None},
@@ -356,18 +356,17 @@ def test_teamwork_project_id_from_dict():
     assert project_id.serverAddress == "https://teamwork.example.com"
     assert project_id.projectName == "MyTeamworkProject"
     assert project_id.teamworkCredentials.username == "user"
-    assert project_id.teamworkCredentials.password == "secret"
+    assert project_id.teamworkCredentials.password.get_secret_value() == "secret"
 
 
+# -------------------------------------------------------------------------
 # Tests for ArchicadLocation class
-
-
+# -------------------------------------------------------------------------
 @pytest.mark.parametrize("is_mac,expected_suffix", [(True, "/Contents/MacOS/ARCHICAD"), (False, "")])
 def test_archicad_location_from_api_response(is_mac, expected_suffix):
     with patch("multiconn_archicad.basic_types.is_using_mac", return_value=is_mac):
         api_response = {"archicadLocation": "/Applications/ARCHICAD"}
         location = ArchicadLocation.from_api_response(api_response)
-
         assert location.archicadLocation == f"/Applications/ARCHICAD{expected_suffix}"
 
 
@@ -383,14 +382,29 @@ def test_archicad_location_from_dict():
     assert location.archicadLocation == "/path/to/archicad"
 
 
-# Tests for APIResponseError class
-
-
+# -------------------------------------------------------------------------
+# Tests for APIResponseError and PendingResponse
+# -------------------------------------------------------------------------
 def test_api_response_error_from_api_response():
     api_response = {"code": 404, "message": "Resource not found"}
     error = APIResponseError.from_api_response(api_response)
     assert error.code == 404
     assert error.message == "Resource not found"
+
+
+def test_api_response_error_from_exception():
+    error = APIResponseError.from_exception(APIErrorBase(
+        code=500,
+        message = "Internal Server Error"
+    ))
+    assert error.code == 500
+    assert error.message == "Internal Server Error"
+
+
+def test_pending_response():
+    pending = PendingResponse()
+    assert pending.code is None
+    assert pending.message == "Identifying..."
 
 
 def test_api_response_error_to_dict():
@@ -406,40 +420,17 @@ def test_api_response_error_from_dict():
     assert error.message == "Resource not found"
 
 
-# Tests for ArchiCadID class
-
-
-def test_archicad_id_register_subclass(reset_archicad_id_registry):
-    # Define a new subclass
-    @dataclass
-    class TestSubclass(ArchiCadID):
-        test_attr: str
-
-        def get_project_location(self, _=None):
-            return self.test_attr
-
-        def to_dict(self):
-            return asdict(self)
-
-        @classmethod
-        def from_dict(cls, data):
-            return cls(**data)
-
-    # Register it
-    ArchiCadID.register_subclass(TestSubclass)
-
-    # Verify it's in the registry
-    assert "TestSubclass" in ArchiCadID._ID_type_registry
-    assert ArchiCadID._ID_type_registry["TestSubclass"] == TestSubclass
-
-
-def test_archicad_id_from_api_response_untitled(reset_archicad_id_registry):
+# -------------------------------------------------------------------------
+# Tests for Polymorphic ArchiCadID Dispatch
+# -------------------------------------------------------------------------
+def test_archicad_id_from_api_response_untitled():
     api_response = {"isUntitled": True, "isTeamwork": False}
     project_id = ArchiCadID.from_api_response(api_response)
     assert isinstance(project_id, UntitledProjectID)
+    assert project_id.projectName == "Untitled"
 
 
-def test_archicad_id_from_api_response_solo(reset_archicad_id_registry):
+def test_archicad_id_from_api_response_solo():
     api_response = {
         "isUntitled": False,
         "isTeamwork": False,
@@ -452,42 +443,44 @@ def test_archicad_id_from_api_response_solo(reset_archicad_id_registry):
     assert project_id.projectName == "MySoloProject"
 
 
-def test_archicad_id_from_api_response_teamwork(reset_archicad_id_registry):
-    with patch("multiconn_archicad.basic_types.TeamworkProjectID.from_project_location") as mock_from_project_location:
-        mock_project_id = MagicMock(spec=TeamworkProjectID)
-        mock_from_project_location.return_value = mock_project_id
-
-        api_response = {
-            "isUntitled": False,
-            "isTeamwork": True,
-            "projectLocation": "teamwork://user:pass@server/project",
-            "projectName": "MyTeamworkProject",
-        }
-        project_id = ArchiCadID.from_api_response(api_response)
-
-        mock_from_project_location.assert_called_once_with(
-            project_location="teamwork://user:pass@server/project", project_name="MyTeamworkProject"
-        )
-        assert project_id == mock_project_id
+def test_archicad_id_from_api_response_teamwork():
+    api_response = {
+        "isUntitled": False,
+        "isTeamwork": True,
+        "projectLocation": "teamwork://user:pass@https://server/project",
+        "projectName": "MyTeamworkProject",
+    }
+    project_id = ArchiCadID.from_api_response(api_response)
+    assert isinstance(project_id, TeamworkProjectID)
+    assert project_id.projectName == "MyTeamworkProject"
+    assert project_id.serverAddress == "https://server"
+    assert project_id.projectPath == "project"
+    assert project_id.teamworkCredentials.username == "user"
+    assert project_id.teamworkCredentials.password.get_secret_value() == "pass"
 
 
-def test_archicad_id_from_dict_untitled(reset_archicad_id_registry):
-    data_dict = {"projectName": "Untitled"}
+def test_archicad_id_from_dict_untitled():
+    data_dict = {"project_type": "untitled", "projectName": "Untitled"}
     project_id = ArchiCadID.from_dict(data_dict)
     assert isinstance(project_id, UntitledProjectID)
     assert project_id.projectName == "Untitled"
 
 
-def test_archicad_id_from_dict_solo(reset_archicad_id_registry):
-    data_dict = {"projectPath": "/path/to/project", "projectName": "MySoloProject"}
+def test_archicad_id_from_dict_solo():
+    data_dict = {
+        "project_type": "solo",
+        "projectPath": "/path/to/project",
+        "projectName": "MySoloProject",
+    }
     project_id = ArchiCadID.from_dict(data_dict)
     assert isinstance(project_id, SoloProjectID)
     assert project_id.projectPath == "/path/to/project"
     assert project_id.projectName == "MySoloProject"
 
 
-def test_archicad_id_from_dict_teamwork(reset_archicad_id_registry):
+def test_archicad_id_from_dict_teamwork():
     data_dict = {
+        "project_type": "teamwork",
         "projectPath": "projects/myproject",
         "serverAddress": "https://teamwork.example.com",
         "teamworkCredentials": {"username": "user", "password": "secret"},
@@ -499,10 +492,10 @@ def test_archicad_id_from_dict_teamwork(reset_archicad_id_registry):
     assert project_id.serverAddress == "https://teamwork.example.com"
     assert project_id.projectName == "MyTeamworkProject"
     assert project_id.teamworkCredentials.username == "user"
-    assert project_id.teamworkCredentials.password == "secret"
+    assert project_id.teamworkCredentials.password.get_secret_value() == "secret"
 
 
-def test_archicad_id_from_dict_invalid(reset_archicad_id_registry):
+def test_archicad_id_from_dict_invalid():
     data_dict = {"invalid": "data"}
-    with pytest.raises(AttributeError, match="can not instantiate ArchiCadID from"):
+    with pytest.raises(ValidationError):
         ArchiCadID.from_dict(data_dict)


### PR DESCRIPTION
### **Description:**

#### **Summary**
Migrates core data structures and connection headers from standard `dataclasses` to **Pydantic V2 (`BaseModel`)**, enabling validation, seamless serialization/deserialization, and native schema support.

#### **Key Changes**
- **Pydantic Migration**: Converted `ProductInfo`, `ArchicadLocation`, `APIResponseError`, `TeamworkCredentials`, and `ArchiCadID` subclasses to Pydantic V2 models.
- **Custom Core Schemas**:
  - Implemented `__get_pydantic_core_schema__` for `Port` (port range constraints: 19723–19743).
  - Added tagged union core schema with discriminator for polymorphic `ArchiCadID` resolution (`untitled`, `solo`, `teamwork`).
  - Added custom schema to serialize/deserialize `ConnHeader` snapshots.
- **Security & Fixes**:
  - Masked teamwork credentials using `SecretStr` (serializes to `None` by default).
  - Aligned `ProductInfo` field names with upstream API (`build` $\to$ `buildNumber`, `lang` $\to$ `languageCode`).
  - Corrected `SwitchProject` path resolution via `get_project_location()`.
- **Cleanup**: Removed deprecated `FromAPIResponse` protocol and unused helper functions.
- **Tests**: Updated unit and integration test suites for Pydantic compatibility.