### PR TITLE
feat: implemented a ram monitor that can monitor the ram usage of an archicad instance, and serialize the max usage

### DIFF
--- a/src/multiconn_archicad/actions/project_handler.py
+++ b/src/multiconn_archicad/actions/project_handler.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 import subprocess
 import time
-import psutil
 import os
 from dataclasses import dataclass
 
@@ -14,6 +13,7 @@ from multiconn_archicad.errors import (
 )
 from multiconn_archicad.utilities.platform_utils import escape_spaces_in_path, is_using_mac
 from multiconn_archicad.utilities.exception_logging import auto_decorate_methods, log_exceptions
+from multiconn_archicad.utilities.process_utils import find_port_by_pid
 from multiconn_archicad.basic_types import Port, TeamworkCredentials, TeamworkProjectID, SoloProjectID
 from multiconn_archicad.conn_header import ConnHeader, has_project_identity
 
@@ -79,11 +79,13 @@ class SwitchProject:
             except StandardAPIError:
                 pass
 
+
 @dataclass
 class ProjectParams:
     conn_header: ConnHeader
     teamwork_credentials: TeamworkCredentials | None
     demo: bool
+
 
 @auto_decorate_methods(log_exceptions)
 class OpenProject:
@@ -142,14 +144,8 @@ class OpenProject:
             text=True,
         )
 
-    def _find_archicad_port(self):
-        psutil_process = psutil.Process(self.process.pid)
-
-        while True:
-            connections = psutil_process.net_connections(kind="inet")
-            for conn in connections:
-                if conn.status == psutil.CONN_LISTEN:
-                    if conn.laddr.port in self.multi_conn.port_range:
-                        log.debug(f"Detected Archicad listening on port {conn.laddr.port}")
-                        return conn.laddr.port
-            time.sleep(1)
+    def _find_archicad_port(self) -> int:
+        port = find_port_by_pid(self.process.pid, self.multi_conn.port_range, timeout=None, poll_interval=1.0)
+        if port is None:
+            raise RuntimeError(f"Archicad process (PID {self.process.pid}) terminated without opening a port.")
+        return port

--- a/src/multiconn_archicad/actions/project_handler.py
+++ b/src/multiconn_archicad/actions/project_handler.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 import subprocess
 import time
 import os
+import psutil
 from dataclasses import dataclass
 
 from multiconn_archicad.errors import (
@@ -105,9 +106,9 @@ class OpenProject:
 
     def _execute_action(self, project_params: ProjectParams) -> Port | None:
         self._check_input(project_params)
+        self._check_ram_advisory(project_params)
         self._open_project(project_params)
-        port = Port(self._find_archicad_port())
-        self.multi_conn.open_port_headers.update({port: ConnHeader(port)})
+        port = self._activate_and_attach_header(project_params.conn_header)
         log.info(
             f"Successfully opened project '{project_params.conn_header.archicad_id.projectName}' "
             f"on port {port} (Process PID: {self.process.pid})"
@@ -128,6 +129,21 @@ class OpenProject:
         if port:
             raise ProjectAlreadyOpenError(f"Project is already open at port: {port}")
 
+    def _check_ram_advisory(self, project_params: ProjectParams) -> None:
+        """Non-blocking diagnostic warning for capacity visibility."""
+        historical_peak = project_params.conn_header.peak_archicad_ram_bytes
+        if historical_peak is not None:
+            try:
+                available_ram = psutil.virtual_memory().available
+                if historical_peak > available_ram:
+                    log.warning(
+                        f"Opening project '{project_params.conn_header.archicad_id.projectName}' with historical "
+                        f"peak RAM of {historical_peak / (1024**3):.2f} GB, but system currently has only "
+                        f"{available_ram / (1024**3):.2f} GB available."
+                    )
+            except Exception as e:
+                log.debug(f"Failed to check available system RAM: {e}")
+
     def _open_project(self, project_params: ProjectParams) -> None:
         self._start_process(project_params)
         self.multi_conn.dialog_handler.start(self.process)
@@ -143,6 +159,13 @@ class OpenProject:
             shell=is_using_mac(),
             text=True,
         )
+
+    def _activate_and_attach_header(self, header: ConnHeader) -> Port:
+        port = Port(self._find_archicad_port())
+        header.port = port
+        header.refresh_metadata()
+        self.multi_conn.open_port_headers[port] = header
+        return port
 
     def _find_archicad_port(self) -> int:
         port = find_port_by_pid(self.process.pid, self.multi_conn.port_range, timeout=None, poll_interval=1.0)

--- a/src/multiconn_archicad/actions/quit.py
+++ b/src/multiconn_archicad/actions/quit.py
@@ -1,43 +1,17 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-import psutil
+import logging
 
 from multiconn_archicad.conn_header import ConnHeader
 from multiconn_archicad.errors import RequestError, ArchicadAPIError
+from multiconn_archicad.utilities.process_utils import find_pid_by_port, terminate_process
 
 if TYPE_CHECKING:
     from multiconn_archicad.multi_conn import MultiConn
     from multiconn_archicad.basic_types import Port
 
-import logging
-
 log = logging.getLogger(__name__)
-
-
-def _find_process_using_port(port: int) -> int | None:
-    """Find the PID of the process using the specified port."""
-    for conn in psutil.net_connections(kind="inet"):
-        if conn.laddr.port == port and conn.status == psutil.CONN_LISTEN:
-            return conn.pid
-    return None
-
-
-def _kill_process(pid: int) -> None:
-    """Kill the process with the given PID."""
-    try:
-        p = psutil.Process(pid)
-        p.terminate()  # Graceful termination
-        try:
-            p.wait(timeout=3)
-            log.info(f"Process with PID {pid} terminated successfully.")
-        except psutil.TimeoutExpired:  # Force termination
-            log.warning(f"Process {pid} did not terminate in time. Force killing.")
-            p.kill()
-    except psutil.NoSuchProcess:
-        log.info(f"No process found with PID {pid}. Already terminated?")
-    except Exception as e:
-        log.error(f"Error killing process PID {pid}: {e}", exc_info=True)
 
 
 class QuitAndDisconnect:
@@ -77,8 +51,8 @@ class QuitAndDisconnect:
             except (RequestError, ArchicadAPIError) as e:
                 log.error(f"Failed to gracefully quit Archicad: error: {e}")
                 if force_after:
-                    if process := _find_process_using_port(conn_header.port):
-                        _kill_process(process)
+                    if process := find_pid_by_port(conn_header.port):
+                        terminate_process(process, graceful_timeout=force_after)
                     else:
                         log.warning(f"Could not find process listening on port {conn_header.port} to force kill.")
                     quit_successful = True

--- a/src/multiconn_archicad/conn_header.py
+++ b/src/multiconn_archicad/conn_header.py
@@ -271,6 +271,7 @@ class ConnHeader:
         self.init_future = EXECUTOR.submit(self._fetch_worker, self._fetch_token)
 
     def _fetch_worker(self, my_token: object) -> HeaderMetadata | None:
+        self._ram_monitor.get_current_rss()
         metadata = HeaderMetadata(
             product_info=self.get_product_info(timeout=5.0),
             archicad_id=self.get_archicad_id(timeout=5.0),

--- a/src/multiconn_archicad/conn_header.py
+++ b/src/multiconn_archicad/conn_header.py
@@ -23,12 +23,13 @@ from multiconn_archicad.basic_types import (
     ArchicadLocation,
     TapirInfo,
     SoloProjectID,
-    TeamworkProjectID
+    TeamworkProjectID,
 )
 from multiconn_archicad.errors import RequestError, ArchicadAPIError, HeaderUnassignedError, AddOnCommandUnavailable
 from multiconn_archicad.standard_connection import StandardConnection
 from multiconn_archicad.unified_api.api import UnifiedApi
 from multiconn_archicad.utilities.thread_utils import EXECUTOR
+from multiconn_archicad.utilities.ram_monitor import RamMonitor
 
 
 log = logging.getLogger(__name__)
@@ -57,12 +58,22 @@ class HeaderMetadata:
 
 
 class ConnHeader:
-    def __init__(self, port: Port | None = None, initialize: bool = True, ui_mode: bool = False):
-
+    def __init__(
+        self,
+        port: Port | None = None,
+        initialize: bool = True,
+        ui_mode: bool = False,
+        initial_peak_ram_bytes: int | None = None,
+    ):
         self._port: Port | None = port
         self._status: Status = Status.PENDING if port else Status.UNASSIGNED
         self._ui_mode: bool = ui_mode
         self._is_cancelled: bool = False
+
+        self._ram_monitor = RamMonitor(
+            port_getter=lambda: self._port,
+            initial_peak_bytes=initial_peak_ram_bytes,
+        )
 
         self._fetch_token: object | None = None
         self.init_future: Future | None = None
@@ -74,8 +85,8 @@ class ConnHeader:
         self._unified: UnifiedApi | None = UnifiedApi(self.core) if self._core else None
 
         self._product_info: ProductInfo | APIResponseError = PendingResponse()
-        self._archicad_id: ArchiCadID | APIResponseError  = PendingResponse()
-        self._archicad_location: ArchicadLocation | APIResponseError  = PendingResponse()
+        self._archicad_id: ArchiCadID | APIResponseError = PendingResponse()
+        self._archicad_location: ArchicadLocation | APIResponseError = PendingResponse()
         self._tapir_info: TapirInfo | APIResponseError = PendingResponse()
 
         if initialize and port:
@@ -93,6 +104,7 @@ class ConnHeader:
     @port.setter
     def port(self, port: Port | None) -> None:
         self._port = port
+        self._ram_monitor.reset_process()
         if port:
             self._core = CoreCommands(port)
             self._standard = StandardConnection(port)
@@ -106,6 +118,20 @@ class ConnHeader:
                     self._status = Status.PENDING
         else:
             self.unassign()
+
+    @property
+    def ram_monitor(self) -> RamMonitor:
+        """Process RAM telemetry and background tracking controller."""
+        return self._ram_monitor
+
+    @property
+    def peak_archicad_ram_bytes(self) -> int | None:
+        """The maximum observed RSS memory usage in bytes for this project."""
+        return self._ram_monitor.peak_bytes
+
+    @peak_archicad_ram_bytes.setter
+    def peak_archicad_ram_bytes(self, value: int | None) -> None:
+        self._ram_monitor.peak_bytes = value
 
     @property
     def core(self) -> CoreCommands:
@@ -159,8 +185,8 @@ class ConnHeader:
             "productInfo": self._product_info.model_dump(),
             "archicadId": self._archicad_id.model_dump(),
             "archicadLocation": self._archicad_location.model_dump(),
+            "peakArchicadRamBytes": self.peak_archicad_ram_bytes,
         }
-
 
     @classmethod
     def from_dict(cls, data: Any) -> Self:
@@ -174,13 +200,12 @@ class ConnHeader:
         instance._product_info = ProductInfo.model_validate(data["productInfo"])
         instance._archicad_id = ArchiCadID.model_validate(data["archicadId"])
         instance._archicad_location = ArchicadLocation.model_validate(data["archicadLocation"])
+        instance.peak_archicad_ram_bytes = data.get("peakArchicadRamBytes")
         return instance
-
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         """Enables Pydantic V2 to serialize/deserialize ConnHeader controllers."""
-
         return core_schema.json_or_python_schema(
             json_schema=core_schema.chain_schema([
                 core_schema.dict_schema(),
@@ -195,7 +220,6 @@ class ConnHeader:
                 when_used="always",
             ),
         )
-
 
     def __eq__(self, other: Any) -> bool:
         if self is other:
@@ -213,14 +237,30 @@ class ConnHeader:
     def __repr__(self) -> str:
         attrs = {
             name: getattr(self, name)
-            for name in ["port", "_status", "product_info", "archicad_id", "archicad_location", "tapir_info"]
+            for name in [
+                "port",
+                "_status",
+                "product_info",
+                "archicad_id",
+                "archicad_location",
+                "tapir_info",
+                "peak_archicad_ram_bytes",
+            ]
         }
         return f"{self.__class__.__name__}({attrs})"
 
     def __str__(self) -> str:
         attrs = {
             name: getattr(self, name)
-            for name in ["port", "_status", "product_info", "archicad_id", "archicad_location", "tapir_info"]
+            for name in [
+                "port",
+                "_status",
+                "product_info",
+                "archicad_id",
+                "archicad_location",
+                "tapir_info",
+                "peak_archicad_ram_bytes",
+            ]
         }
         return f"{self.__class__.__name__}(\n{pformat(attrs, width=200, indent=4)})"
 
@@ -265,6 +305,7 @@ class ConnHeader:
 
     def unassign(self) -> None:
         self.cancel()
+        self._ram_monitor.reset_process()
         self._status = Status.UNASSIGNED
         self._port = None
         self._core = None
@@ -275,21 +316,23 @@ class ConnHeader:
         self._is_cancelled = True
 
     def sync_from_master_future(self, master_future: Future) -> None:
-        """ Links this header to a master future."""
+        """Links this header to a master future."""
         self.init_future = master_future
         self._auto_connect = True
 
     def _sync_if_needed(self):
         """Safely unpacks the future when data is needed or ready."""
-        if (not self.init_future or
-            self.init_future is self._unpacked_future or
-            threading.current_thread().name.startswith("MultiConnWorker")):
+        if (
+            not self.init_future
+            or self.init_future is self._unpacked_future
+            or threading.current_thread().name.startswith("MultiConnWorker")
+        ):
             return
 
-        if self._ui_mode: # UI Mode: Only unpack if the background thread is already done (non-blocking)
+        if self._ui_mode:  # UI Mode: Only unpack if background thread is done
             if self.init_future.done():
                 self._unpack_future()
-        else: # Standard Mode: Safely block and wait for the data
+        else:  # Standard Mode: Safely block and wait for data
             self._unpack_future()
 
     def _unpack_future(self) -> None:
@@ -374,8 +417,10 @@ class ProjectIdentityHeader(ConnHeader):
     archicad_id: SoloProjectID | TeamworkProjectID
     archicad_location: ArchicadLocation
 
+
 # Deprecation Alias
 ValidatedHeader = ProjectIdentityHeader
+
 
 class SessionReadyHeader(ProjectIdentityHeader):
     """Guaranteed to be active, connected to a port, with Tapir polled."""

--- a/src/multiconn_archicad/utilities/process_utils.py
+++ b/src/multiconn_archicad/utilities/process_utils.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Iterable
+import psutil
+
+log = logging.getLogger(__name__)
+
+
+def find_pid_by_port(port: int) -> int | None:
+    """Find the PID of the process listening on the specified port."""
+    try:
+        for conn in psutil.net_connections(kind="inet"):
+            if conn.laddr.port == port and conn.status == psutil.CONN_LISTEN:
+                return conn.pid
+    except (psutil.AccessDenied, psutil.NoSuchProcess, Exception) as e:
+        log.debug(f"Failed to query network connections for port {port}: {e}")
+    return None
+
+
+def find_port_by_pid(
+    pid: int,
+    allowed_ports: Iterable[int],
+    timeout: float | None = None,
+    poll_interval: float = 1.0,
+) -> int | None:
+    """
+    Polls a process until it opens a listening socket on one of the allowed ports.
+    If timeout is None, polls indefinitely until a listening port is found or the process dies.
+    """
+    allowed_set = set(allowed_ports)
+    start_time = time.monotonic()
+
+    psutil_process = psutil.Process(pid)
+
+    while True:
+        try:
+            connections = psutil_process.net_connections(kind="inet")
+            for conn in connections:
+                if conn.status == psutil.CONN_LISTEN and conn.laddr.port in allowed_set:
+                    log.debug(f"Detected Archicad listening on port {conn.laddr.port}")
+                    return conn.laddr.port
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            log.warning(f"Process PID {pid} terminated while waiting for listening port.")
+            return None
+        except psutil.AccessDenied as e:
+            log.debug(f"Access denied querying network connections for PID {pid}: {e}")
+
+        if timeout is not None and (time.monotonic() - start_time) >= timeout:
+            log.error(f"Timed out after {timeout}s waiting for PID {pid} to listen on allowed ports.")
+            return None
+
+        time.sleep(poll_interval)
+
+
+def get_process_rss_bytes(pid: int) -> int | None:
+    """Returns the current Resident Set Size (RSS) memory in bytes for the given PID."""
+    try:
+        return psutil.Process(pid).memory_info().rss
+    except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied):
+        return None
+    except Exception as e:
+        log.debug(f"Error querying memory for PID {pid}: {e}")
+        return None
+
+
+def terminate_process(pid: int, graceful_timeout: float = 60.0) -> None:
+    """Gracefully terminates a process, falling back to force-kill if it exceeds the timeout."""
+    try:
+        p = psutil.Process(pid)
+        p.terminate()  # Graceful termination
+        try:
+            p.wait(timeout=graceful_timeout)
+            log.info(f"Process with PID {pid} terminated successfully.")
+        except psutil.TimeoutExpired:
+            log.warning(f"Process {pid} did not terminate in time. Force killing.")
+            p.kill()
+    except psutil.NoSuchProcess:
+        log.info(f"No process found with PID {pid}. Already terminated?")
+    except Exception as e:
+        log.error(f"Error killing process PID {pid}: {e}", exc_info=True)

--- a/src/multiconn_archicad/utilities/ram_monitor.py
+++ b/src/multiconn_archicad/utilities/ram_monitor.py
@@ -49,8 +49,10 @@ class RamMonitor:
 
     @property
     def peak_bytes(self) -> int | None:
-        """The highest observed RSS memory usage in bytes."""
-        return self._peak.get()
+        val = self._peak.get()
+        if val is None:
+            return self.get_current_rss()
+        return val
 
     @peak_bytes.setter
     def peak_bytes(self, value: int | None) -> None:
@@ -133,7 +135,7 @@ class RamMonitor:
         self._cached_pid = None
 
     @contextmanager
-    def track_peak_ram(self, interval_s: float = 1.0) -> Iterator[None]:
+    def track(self, interval_s: float = 1.0) -> Iterator[None]:
         """Context manager to track peak RAM during an enclosed block of work."""
         self.start(interval_s=interval_s)
         try:

--- a/src/multiconn_archicad/utilities/ram_monitor.py
+++ b/src/multiconn_archicad/utilities/ram_monitor.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import logging
+import threading
+from contextlib import contextmanager
+from typing import Callable, Iterator
+import psutil
+
+from multiconn_archicad.utilities.process_utils import find_pid_by_port, get_process_rss_bytes
+
+log = logging.getLogger(__name__)
+
+
+class AtomicPeak:
+    """Thread-safe container for tracking maximum recorded integer values."""
+
+    def __init__(self, initial_value: int | None = None) -> None:
+        self._value: int | None = initial_value
+        self._lock = threading.Lock()
+
+    def update_if_greater(self, new_value: int) -> None:
+        with self._lock:
+            if self._value is None or new_value > self._value:
+                self._value = new_value
+
+    def get(self) -> int | None:
+        with self._lock:
+            return self._value
+
+    def set(self, value: int | None) -> None:
+        with self._lock:
+            self._value = value
+
+
+class RamMonitor:
+    """Encapsulates process memory tracking, live RSS queries, and background peak RAM polling."""
+
+    def __init__(
+        self,
+        port_getter: Callable[[], int | None] | None = None,
+        initial_peak_bytes: int | None = None,
+    ) -> None:
+        self._port_getter = port_getter
+        self._peak = AtomicPeak(initial_peak_bytes)
+        self._cached_pid: int | None = None
+
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @property
+    def peak_bytes(self) -> int | None:
+        """The highest observed RSS memory usage in bytes."""
+        return self._peak.get()
+
+    @peak_bytes.setter
+    def peak_bytes(self, value: int | None) -> None:
+        self._peak.set(value)
+
+    @property
+    def current_bytes(self) -> int | None:
+        """Queries live RSS memory and automatically updates peak RAM if exceeded."""
+        return self.get_current_rss()
+
+    @property
+    def pid(self) -> int | None:
+        """Returns the PID of the Archicad process associated with the port."""
+        return self.get_pid()
+
+    @property
+    def is_polling(self) -> bool:
+        """Indicates whether background polling is actively running."""
+        return self._thread is not None and self._thread.is_alive()
+
+    def get_pid(self) -> int | None:
+        """Resolves the PID using the cached PID or port lookup."""
+        if self._cached_pid is not None:
+            if psutil.pid_exists(self._cached_pid):
+                return self._cached_pid
+            self._cached_pid = None
+
+        if self._port_getter is None:
+            return None
+
+        port = self._port_getter()
+        if port is None:
+            return None
+
+        pid = find_pid_by_port(port)
+        self._cached_pid = pid
+        return pid
+
+    def get_current_rss(self) -> int | None:
+        """Queries live process RSS and atomically updates peak RAM if exceeded."""
+        pid = self.get_pid()
+        if pid is None:
+            return None
+
+        current_rss = get_process_rss_bytes(pid)
+        if current_rss is not None:
+            self._peak.update_if_greater(current_rss)
+
+        return current_rss
+
+    def start(self, interval_s: float = 1.0) -> None:
+        """Starts a background daemon thread polling memory at the given interval."""
+        if self.is_polling:
+            log.debug("RAM polling is already active.")
+            return
+
+        self._stop_event.clear()
+        port_label = self._port_getter() if self._port_getter else "unassigned"
+        self._thread = threading.Thread(
+            target=self._polling_worker,
+            args=(interval_s,),
+            name=f"RamMonitorWorker-port-{port_label}",
+            daemon=True,
+        )
+        self._thread.start()
+        log.debug(f"Started background RAM polling (interval={interval_s}s).")
+
+    def stop(self) -> int | None:
+        """Stops the background polling thread cleanly and returns the peak bytes."""
+        self._stop_event.set()
+        if self._thread is not None and threading.current_thread() != self._thread:
+            self._thread.join(timeout=3.0)
+            self._thread = None
+            log.debug("Stopped background RAM polling.")
+        return self.peak_bytes
+
+    def reset_process(self) -> None:
+        """Stops active polling and clears the cached PID while retaining peak RAM metrics."""
+        self.stop()
+        self._cached_pid = None
+
+    @contextmanager
+    def track_peak_ram(self, interval_s: float = 1.0) -> Iterator[None]:
+        """Context manager to track peak RAM during an enclosed block of work."""
+        self.start(interval_s=interval_s)
+        try:
+            yield
+        finally:
+            self.stop()
+
+    def _polling_worker(self, interval_s: float) -> None:
+        """Background thread worker loop. Immediately takes a sample, then polls on interval."""
+        self.get_current_rss()
+        while not self._stop_event.wait(timeout=interval_s):
+            self.get_current_rss()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,7 @@ def archicad_api(monkeypatch):
     Starts the synchronous mock server on a background thread within the Archicad port range,
     and patches the library configuration.
     """
+    assert_no_running_archicad()
     controller = ServerController()
 
     valid_ports = range(19723, 19745)
@@ -191,7 +192,7 @@ def fuzz_threads():
         sys.setswitchinterval(original_interval)
 
 
-def pytest_sessionstart(session):
+def assert_no_running_archicad():
     """
     Pre-flight guard to ensure no real Archicad instances or lingering processes
     are listening on the standard port range (19723-19743) that can interfere with the tests.

--- a/tests/integration/test_project_management.py
+++ b/tests/integration/test_project_management.py
@@ -128,8 +128,8 @@ def test_open_project_calls_dependencies_correctly(
     # 2. Verify dialog handler was started
     conn.dialog_handler.start.assert_called_once_with(mock_process)
 
-    # 3. Verify psutil was used to find the port
-    mock_psutil_process.assert_called_once_with(12345)
+    # 3. Verify psutil was called for PID 12345 and polled network connections
+    mock_psutil_process.assert_any_call(12345)
     assert mock_psutil_instance.net_connections.call_count == 3
 
     # 4. Verify a new header was added for the new port

--- a/tests/unit/test_ram_monitor.py
+++ b/tests/unit/test_ram_monitor.py
@@ -1,11 +1,13 @@
 import time
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+
 from multiconn_archicad.basic_types import Port, ProductInfo, SoloProjectID, ArchicadLocation
 from multiconn_archicad.conn_header import ConnHeader
 from multiconn_archicad.utilities.ram_monitor import AtomicPeak, RamMonitor
 
 
-def test_atomic_peak():
+def test_atomic_peak_logic():
+    """Verifies that AtomicPeak only updates when a strictly larger value is supplied."""
     peak = AtomicPeak(100)
     assert peak.get() == 100
 
@@ -19,57 +21,137 @@ def test_atomic_peak():
     assert peak.get() == 300
 
 
-def test_ram_monitor_live_query():
+def test_peak_bytes_lazy_self_healing_query():
+    """
+    Verifies that accessing peak_bytes on an unpolled header lazily samples
+    the live RSS once and caches it as the initial peak.
+    """
     port = Port(19723)
     monitor = RamMonitor(port_getter=lambda: port)
 
     with patch("multiconn_archicad.utilities.ram_monitor.find_pid_by_port", return_value=12345):
-        with patch("multiconn_archicad.utilities.ram_monitor.get_process_rss_bytes", side_effect=[1000, 2500, 1500]):
-            assert monitor.current_bytes == 1000
-            assert monitor.peak_bytes == 1000
+        with patch("multiconn_archicad.utilities.ram_monitor.get_process_rss_bytes", return_value=2_147_483_648) as mock_rss:
+            # 1. Initially _peak is None, so peak_bytes lazily triggers get_current_rss()
+            assert monitor.peak_bytes == 2_147_483_648
+            mock_rss.assert_called_once_with(12345)
 
-            assert monitor.current_bytes == 2500
-            assert monitor.peak_bytes == 2500
-
-            assert monitor.current_bytes == 1500
-            assert monitor.peak_bytes == 2500  # Peak stays at 2500
-
-
-def test_ram_monitor_track_context_manager():
-    port = Port(19723)
-    monitor = RamMonitor(port_getter=lambda: port)
-
-    with patch("multiconn_archicad.utilities.ram_monitor.find_pid_by_port", return_value=12345):
-        with patch("multiconn_archicad.utilities.ram_monitor.get_process_rss_bytes", side_effect=[500, 1500, 3000, 2000]):
-            with monitor.track_peak_ram(interval_s=0.05):
-                assert monitor.is_polling
-                time.sleep(0.15)
-
-            assert not monitor.is_polling
-            assert monitor.peak_bytes == 3000
+            # 2. Subsequent reads must use the cached peak without re-querying
+            mock_rss.reset_mock()
+            assert monitor.peak_bytes == 2_147_483_648
+            mock_rss.assert_not_called()
 
 
-def test_header_serialization_with_peak_ram():
+def test_unassigned_header_peak_is_none_not_zero():
+    """
+    Locks the contract that unassigned/unmeasured headers return None, NOT 0,
+    preventing orchestrator OOM scheduling bugs.
+    """
     header = ConnHeader(initialize=False)
-    header._product_info = ProductInfo(version=27, buildNumber=3001, languageCode="INT")
-    header._archicad_id = SoloProjectID(projectPath="/path/to/project.pln", projectName="TestProject")
-    header._archicad_location = ArchicadLocation(archicadLocation="/path/to/Archicad")
-    header.peak_archicad_ram_bytes = 4_294_967_296  # 4 GB
 
-    serialized = header.to_dict()
-    assert serialized["peakArchicadRamBytes"] == 4_294_967_296
-
-    restored = ConnHeader.from_dict(serialized)
-    assert restored.peak_archicad_ram_bytes == 4_294_967_296
-    assert restored.product_info.version == 27
-    assert restored.archicad_id.projectName == "TestProject"
+    assert header.port is None
+    assert header.peak_archicad_ram_bytes is None
+    assert header.peak_archicad_ram_bytes != 0
+    assert header.ram_monitor.current_bytes is None
 
 
-def test_header_unassign_preserves_peak_ram():
+def test_fetch_worker_auto_seeds_peak_ram_in_background():
+    """
+    Verifies that ConnHeader._fetch_worker automatically records the initial
+    process RSS in the background without requiring manual polling calls.
+    """
     header = ConnHeader(port=Port(19723), initialize=False)
-    header.peak_archicad_ram_bytes = 1024
+
+    # Mock API fetch calls
+    header.get_product_info = MagicMock(return_value=ProductInfo(version=27, buildNumber=3001, languageCode="INT"))
+    header.get_archicad_id = MagicMock(return_value=SoloProjectID(projectPath="/path.pln", projectName="Test"))
+    header.get_archicad_location = MagicMock(return_value=ArchicadLocation(archicadLocation="/app"))
+    header.get_tapir_info = MagicMock()
+
+    with patch("multiconn_archicad.utilities.ram_monitor.find_pid_by_port", return_value=12345):
+        with patch("multiconn_archicad.utilities.ram_monitor.get_process_rss_bytes", return_value=3_221_225_472):
+            # Run fetch worker
+            token = object()
+            header._fetch_token = token
+            header._fetch_worker(token)
+
+            # Assert peak RAM is now auto-seeded
+            assert header.peak_archicad_ram_bytes == 3_221_225_472
+
+
+def test_to_dict_serialization_with_auto_seeded_peak_ram():
+    """
+    Verifies that to_dict() serializes peakArchicadRamBytes accurately
+    when seeded by live process queries.
+    """
+    header = ConnHeader(port=Port(19723), initialize=False)
+    header._product_info = ProductInfo(version=27, buildNumber=3001, languageCode="INT")
+    header._archicad_id = SoloProjectID(projectPath="/path/project.pln", projectName="TestProject")
+    header._archicad_location = ArchicadLocation(archicadLocation="/path/to/Archicad")
+
+    with patch("multiconn_archicad.utilities.ram_monitor.find_pid_by_port", return_value=12345):
+        with patch("multiconn_archicad.utilities.ram_monitor.get_process_rss_bytes", return_value=4_294_967_296):
+            # to_dict calls peak_archicad_ram_bytes, which lazily samples 4GB
+            data = header.to_dict()
+
+            assert data["peakArchicadRamBytes"] == 4_294_967_296
+            assert data["archicadId"]["projectName"] == "TestProject"
+
+
+def test_from_dict_restores_historical_peak_without_process_query():
+    """
+    Verifies that from_dict restores saved peakArchicadRamBytes without attempting
+    to query defunct PIDs or live processes.
+    """
+    snapshot = {
+        "productInfo": {"version": 27, "buildNumber": 3001, "languageCode": "INT"},
+        "archicadId": {"project_type": "solo", "projectPath": "/path/project.pln", "projectName": "Snapshot"},
+        "archicadLocation": {"archicadLocation": "/path/to/Archicad"},
+        "peakArchicadRamBytes": 8_589_934_592,  # 8 GB
+    }
+
+    with patch("multiconn_archicad.utilities.ram_monitor.find_pid_by_port") as mock_find_pid:
+        restored = ConnHeader.from_dict(snapshot)
+
+        assert restored.port is None
+        assert restored.peak_archicad_ram_bytes == 8_589_934_592
+        # Must not attempt to inspect live OS connections
+        mock_find_pid.assert_not_called()
+
+
+def test_unassign_preserves_peak_ram_and_clears_transport():
+    """
+    Verifies that unassigning a header clears active port handles and stops polling,
+    but strictly preserves historic peak_archicad_ram_bytes.
+    """
+    header = ConnHeader(port=Port(19723), initialize=False)
+    header.peak_archicad_ram_bytes = 1_073_741_824  # 1 GB
 
     header.unassign()
+
     assert header.port is None
-    assert header.peak_archicad_ram_bytes == 1024
+    assert header.status.value == "unassigned"
+    # Preserved profile data
+    assert header.peak_archicad_ram_bytes == 1_073_741_824
+    # Live RSS is None because no process/port is attached
     assert header.ram_monitor.current_bytes is None
+
+
+def test_track_context_manager_records_highest_spike():
+    """
+    Verifies that the track() context manager polls in the background and
+    captures the highest observed peak during an operation.
+    """
+    port = Port(19723)
+    monitor = RamMonitor(port_getter=lambda: port)
+
+    with patch("multiconn_archicad.utilities.ram_monitor.find_pid_by_port", return_value=12345):
+        with patch(
+            "multiconn_archicad.utilities.ram_monitor.get_process_rss_bytes",
+            side_effect=[1_000_000, 3_000_000, 7_000_000, 4_000_000],
+        ):
+            with monitor.track(interval_s=0.02):
+                assert monitor.is_polling
+                time.sleep(0.08)
+
+            assert not monitor.is_polling
+            assert monitor.peak_bytes == 7_000_000

--- a/tests/unit/test_ram_monitor.py
+++ b/tests/unit/test_ram_monitor.py
@@ -1,0 +1,75 @@
+import time
+from unittest.mock import patch
+from multiconn_archicad.basic_types import Port, ProductInfo, SoloProjectID, ArchicadLocation
+from multiconn_archicad.conn_header import ConnHeader
+from multiconn_archicad.utilities.ram_monitor import AtomicPeak, RamMonitor
+
+
+def test_atomic_peak():
+    peak = AtomicPeak(100)
+    assert peak.get() == 100
+
+    peak.update_if_greater(50)
+    assert peak.get() == 100
+
+    peak.update_if_greater(200)
+    assert peak.get() == 200
+
+    peak.set(300)
+    assert peak.get() == 300
+
+
+def test_ram_monitor_live_query():
+    port = Port(19723)
+    monitor = RamMonitor(port_getter=lambda: port)
+
+    with patch("multiconn_archicad.utilities.ram_monitor.find_pid_by_port", return_value=12345):
+        with patch("multiconn_archicad.utilities.ram_monitor.get_process_rss_bytes", side_effect=[1000, 2500, 1500]):
+            assert monitor.current_bytes == 1000
+            assert monitor.peak_bytes == 1000
+
+            assert monitor.current_bytes == 2500
+            assert monitor.peak_bytes == 2500
+
+            assert monitor.current_bytes == 1500
+            assert monitor.peak_bytes == 2500  # Peak stays at 2500
+
+
+def test_ram_monitor_track_context_manager():
+    port = Port(19723)
+    monitor = RamMonitor(port_getter=lambda: port)
+
+    with patch("multiconn_archicad.utilities.ram_monitor.find_pid_by_port", return_value=12345):
+        with patch("multiconn_archicad.utilities.ram_monitor.get_process_rss_bytes", side_effect=[500, 1500, 3000, 2000]):
+            with monitor.track_peak_ram(interval_s=0.05):
+                assert monitor.is_polling
+                time.sleep(0.15)
+
+            assert not monitor.is_polling
+            assert monitor.peak_bytes == 3000
+
+
+def test_header_serialization_with_peak_ram():
+    header = ConnHeader(initialize=False)
+    header._product_info = ProductInfo(version=27, buildNumber=3001, languageCode="INT")
+    header._archicad_id = SoloProjectID(projectPath="/path/to/project.pln", projectName="TestProject")
+    header._archicad_location = ArchicadLocation(archicadLocation="/path/to/Archicad")
+    header.peak_archicad_ram_bytes = 4_294_967_296  # 4 GB
+
+    serialized = header.to_dict()
+    assert serialized["peakArchicadRamBytes"] == 4_294_967_296
+
+    restored = ConnHeader.from_dict(serialized)
+    assert restored.peak_archicad_ram_bytes == 4_294_967_296
+    assert restored.product_info.version == 27
+    assert restored.archicad_id.projectName == "TestProject"
+
+
+def test_header_unassign_preserves_peak_ram():
+    header = ConnHeader(port=Port(19723), initialize=False)
+    header.peak_archicad_ram_bytes = 1024
+
+    header.unassign()
+    assert header.port is None
+    assert header.peak_archicad_ram_bytes == 1024
+    assert header.ram_monitor.current_bytes is None

--- a/tests/unit/test_ram_monitor.py
+++ b/tests/unit/test_ram_monitor.py
@@ -1,5 +1,6 @@
 import time
 from unittest.mock import patch, MagicMock
+import threading
 
 from multiconn_archicad.basic_types import Port, ProductInfo, SoloProjectID, ArchicadLocation
 from multiconn_archicad.conn_header import ConnHeader
@@ -144,14 +145,27 @@ def test_track_context_manager_records_highest_spike():
     port = Port(19723)
     monitor = RamMonitor(port_getter=lambda: port)
 
+    all_samples_polled = threading.Event()
+    samples = [1_000_000, 3_000_000, 7_000_000, 4_000_000]
+    sample_iter = iter(samples)
+
+    def mock_rss(pid):
+        try:
+            val = next(sample_iter)
+            if val == 4_000_000:
+                all_samples_polled.set()
+            return val
+        except StopIteration:
+            return 4_000_000
+
     with patch("multiconn_archicad.utilities.ram_monitor.find_pid_by_port", return_value=12345):
         with patch(
             "multiconn_archicad.utilities.ram_monitor.get_process_rss_bytes",
-            side_effect=[1_000_000, 3_000_000, 7_000_000, 4_000_000],
+            side_effect=mock_rss,
         ):
-            with monitor.track(interval_s=0.02):
+            with monitor.track(interval_s=0.01):
                 assert monitor.is_polling
-                time.sleep(0.08)
+                assert all_samples_polled.wait(timeout=3.0), "Background polling did not consume all samples in time"
 
             assert not monitor.is_polling
             assert monitor.peak_bytes == 7_000_000


### PR DESCRIPTION
#### **Summary**
Introduces the `RamMonitor` utility to track live and peak Resident Set Size (RSS) memory consumption of Archicad instances, embeds memory telemetry into `ConnHeader` snapshots, and adds diagnostic warnings when launching projects with high historical RAM requirements.

#### **Key Changes**
- **RAM Monitoring Engine (`RamMonitor` & `AtomicPeak`)**:
  - Thread-safe tracking of peak RSS memory consumption with background polling support.
  - Added `track()` context manager for profiling memory usage during specific operations.
  - Lazy evaluation: Accessing `peak_bytes` on an unpolled active header automatically samples live RSS.
- **ConnHeader Telemetry & Serialization**:
  - Added `peak_archicad_ram_bytes` property, auto-seeded during metadata background fetching.
  - Serialized `peakArchicadRamBytes` into `to_dict()` and restored it in `from_dict()`.
  - Process unassignment preserves historic peak metrics while clearing live handles.
- **Process Utilities & Project Launch Improvements**:
  - Added `process_utils.py` to unify PID/port resolution (`find_pid_by_port`, `find_port_by_pid`, `terminate_process`).
  - Added non-blocking RAM advisory in `OpenProject`: warns if historical peak usage exceeds currently available system RAM.
  - Updated `OpenProject` to activate and attach the existing `ConnHeader` instance instead of spawning a disconnected one.
- **Tests**:
  - Added unit test suite covering `AtomicPeak`, `RamMonitor`, background polling, and snapshot serialization (`test_ram_monitor.py`).
  - Added clean fixture guards to prevent port conflicts during test runs.