### PR TITLE
feat: Overhaul Pydantic ConfigDict merging for explicit mixin precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,17 +155,19 @@ For workflows that require custom validation, immutability, or extra functionali
 
 `configure()` **must** be called before importing any model classes (`commands`, `types`, etc.). If called after models are already imported and compiled, it will raise a `RuntimeError` to prevent silent configuration drift.
 
+> **Configuration Precedence:** Model settings follow a strict hierarchy: **Baseline Defaults $\rightarrow$ Injected Mixins $\rightarrow$ Concrete Model Overrides** (for example, models explicitly declaring `extra="allow"` will always take precedence over mixin restrictions).
+
 ```python
 from multiconn_archicad.models.config import configure
 from multiconn_archicad.models.mixins import (
-    StrictValidationMixin,
+    ForbidExtrasMixin,
     FrozenMixin,
     StripWhitespaceMixin,
     OmitDefaultsMixin,
 )
 
 # Configure the base models for your application
-configure(StrictValidationMixin, StripWhitespaceMixin)
+configure(ForbidExtrasMixin, StripWhitespaceMixin)
 
 # Now safely import model classes (this locks the configuration)
 from multiconn_archicad.models.tapir.commands import CreateBeamsParameters
@@ -178,7 +180,9 @@ The library includes several common mixins out-of-the-box:
 
 | Mixin | Purpose | Common Use Case |
 | :--- | :--- | :--- |
-| **`StrictValidationMixin`** | Forbids unexpected/extra fields on models. Raises `ValueError` on extra input keys. | **MCP Servers / LLM Tool Calling** to catch hallucinated parameters. |
+| **`ForbidExtrasMixin`** | Forbids unexpected/extra fields on models. Raises `ValidationError` on extra input keys. | **MCP Servers / LLM Tool Calling** to catch hallucinated parameters. |
+| **`ContextualForbidExtrasMixin`** | Forbids extra fields by default, but allows context bypass (`ignore_extra_keys`). | Validating user inputs strictly while allowing loose API returns. |
+| **`StrictMixin`** | Enforces strict type validation (`strict=True`), preventing automatic type coercion. | Catching type mismatches (e.g., passing `"1"` for an `int`). |
 | **`FrozenMixin`** | Sets `frozen=True` on all models, making them immutable and hashable. | Thread safety, using models in `set()` or as `dict` keys. |
 | **`StripWhitespaceMixin`** | Automatically strips leading and trailing whitespace from all string fields. | Cleaning up messy user-entered BIM data. |
 | **`OmitDefaultsMixin`** | Excludes fields with default/None values from `.model_dump()` and `.model_dump_json()`. | Minimizing HTTP payload sizes. |

--- a/src/multiconn_archicad/models/base.py
+++ b/src/multiconn_archicad/models/base.py
@@ -2,16 +2,24 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict
 from .config import _Registry
 
+_DEFAULT_CONFIG: dict[str, Any] = {
+    "extra": "ignore",
+    "populate_by_name": True,
+    "serialize_by_alias": True,
+}
+
+_merged_config = dict(_DEFAULT_CONFIG)
+for mixin in _Registry.mixins:
+    if hasattr(mixin, "model_config"):
+        _merged_config.update(mixin.model_config)
+
 _bases = _Registry.mixins + (BaseModel,)
+
 
 class APIModel(*_bases):
     """A custom base model for the Unified API"""
 
-    model_config = ConfigDict(
-        extra="ignore",
-        populate_by_name=True,
-        serialize_by_alias=True,
-    )
+    model_config = ConfigDict(**_merged_config)
 
     def model_dump(
         self,
@@ -38,6 +46,7 @@ class APIModel(*_bases):
             exclude_none=exclude_none,
             **kwargs,
         )
+
 
 # =====================================================================
 # LOCK CONFIGURATION

--- a/src/multiconn_archicad/models/mixins.py
+++ b/src/multiconn_archicad/models/mixins.py
@@ -3,36 +3,59 @@ from pydantic import BaseModel, ConfigDict, model_validator, ValidationInfo
 
 _MODEL_KEYS_CACHE: dict[type, set[str]] = {}
 
-class StrictValidationMixin(BaseModel):
+def _get_allowed_keys(cls: type[BaseModel]) -> set[str]:
+    """Helper for context-based validation to extract and cache allowed field names and aliases."""
+    allowed_keys = _MODEL_KEYS_CACHE.get(cls)
+    if allowed_keys is None:
+        allowed_keys = set(cls.model_fields.keys())
+        for field in cls.model_fields.values():
+            if field.alias:
+                allowed_keys.add(field.alias)
+        _MODEL_KEYS_CACHE[cls] = allowed_keys
+    return allowed_keys
+
+
+class ForbidExtrasMixin(BaseModel):
     """
-    Enforces strict validation by rejecting unknown keys that can be turned off using validation context.
-    Designed for MCP Servers / LLM inputs.
+    Enforces strict schema compliance by forbidding extra/unknown fields using native Pydantic config.
+    Concrete models configured with extra='allow' (e.g. AddOnCommandParameters) will override this.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+
+class ContextualForbidExtrasMixin(BaseModel):
+    """
+    Forbids extra/unknown keys by default, but allows bypassing via validation context:
+        model.model_validate(data, context={"ignore_extra_keys": True})
+
+    Useful for strictly validating user/LLM inputs while optionally allowing loose API returns.
     """
 
     @model_validator(mode="before")
     @classmethod
-    def forbid_extras_unless_api(cls, data: Any, info: ValidationInfo):
+    def forbid_extras_unless_context(cls, data: Any, info: ValidationInfo) -> Any:
         if info.context and info.context.get("ignore_extra_keys"):
             return data
         if cls.model_config.get("extra") == "allow":
             return data
 
         if isinstance(data, dict):
-            allowed_keys = _MODEL_KEYS_CACHE.get(cls)
-            if allowed_keys is None:
-                allowed_keys = set(cls.model_fields.keys())
-                for field in cls.model_fields.values():
-                    if field.alias:
-                        allowed_keys.add(field.alias)
-                _MODEL_KEYS_CACHE[cls] = allowed_keys
-
+            allowed_keys = _get_allowed_keys(cls)
             extra_keys = data.keys() - allowed_keys
             if extra_keys:
                 raise ValueError(
-                    f"Extra fields not allowed in {cls.__name__}: {', '.join(extra_keys)}"
+                    f"Extra fields not allowed in {cls.__name__}: {', '.join(sorted(extra_keys))}"
                 )
 
         return data
+
+
+class StrictMixin(BaseModel):
+    """
+    Enforces strict Pydantic type validation (`strict=True`).
+    Disallows type coercions (e.g. "123" -> 123, 1.0 -> 1, "true" -> True).
+    """
+    model_config = ConfigDict(strict=True)
 
 
 class FrozenMixin(BaseModel):

--- a/tests/unit/test_config_precedence.py
+++ b/tests/unit/test_config_precedence.py
@@ -1,0 +1,157 @@
+import pytest
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+
+# =========================================================================
+# TIER 1: Baseline Defaults (No Mixins Configured)
+# =========================================================================
+
+def test_tier_1_baseline_defaults_apply_when_no_mixins(clean_models):
+    """
+    Proves that without mixins:
+    1. Baseline extra="ignore" silently drops unknown fields.
+    2. Baseline populate_by_name=True and serialize_by_alias=True are active.
+    """
+    from multiconn_archicad.models.base import APIModel
+    from multiconn_archicad.models.tapir.types import Coordinate2D
+
+    # 1. Config inspect: baseline has extra='ignore' and populate_by_name=True
+    assert APIModel.model_config.get("extra") == "ignore"
+    assert APIModel.model_config.get("populate_by_name") is True
+    assert APIModel.model_config.get("serialize_by_alias") is True
+
+    # 2. Functional check: Extra keys are silently ignored (not raising errors)
+    coord = Coordinate2D.model_validate({"x": 10.0, "y": 20.0, "extra_ignored_key": "xyz"})
+    assert coord.x == 10.0
+    assert coord.y == 20.0
+    assert not hasattr(coord, "extra_ignored_key")
+
+
+# =========================================================================
+# TIER 2: Mixin Overrides Baseline Config
+# =========================================================================
+
+def test_tier_2_mixin_overrides_baseline_and_preserves_other_defaults(clean_models):
+    """
+    Proves that injecting ForbidExtrasMixin:
+    1. Overrides baseline extra="ignore" -> extra="forbid".
+    2. Preserves other non-conflicting baseline defaults (populate_by_name, serialize_by_alias).
+    """
+    from multiconn_archicad.models.config import configure
+    from multiconn_archicad.models.mixins import ForbidExtrasMixin
+
+    # Inject the mixin
+    configure(ForbidExtrasMixin)
+
+    from multiconn_archicad.models.base import APIModel
+    from multiconn_archicad.models.tapir.types import Coordinate2D
+
+    # 1. Config inspect: extra was overridden by mixin, baseline keys were preserved
+    assert APIModel.model_config.get("extra") == "forbid"
+    assert APIModel.model_config.get("populate_by_name") is True
+    assert APIModel.model_config.get("serialize_by_alias") is True
+
+    # 2. Functional check: Standard model now raises ValidationError on extra keys
+    with pytest.raises(ValidationError) as exc_info:
+        Coordinate2D.model_validate({"x": 1.0, "y": 2.0, "forbidden_extra": 123})
+
+    # Ensure the error is specifically Pydantic's native 'extra_forbidden'
+    errors = exc_info.value.errors()
+    assert any(err["type"] == "extra_forbidden" for err in errors)
+
+
+# =========================================================================
+# TIER 3: Concrete Model Overrides Both Base and Mixin
+# =========================================================================
+
+def test_tier_3_concrete_model_overrides_mixin(clean_models):
+    """
+    Proves that a leaf model with an explicit ConfigDict (e.g. extra="allow"):
+    1. Overrides the mixin's extra="forbid".
+    2. Overrides the baseline's extra="ignore".
+    """
+    from multiconn_archicad.models.config import configure
+    from multiconn_archicad.models.mixins import ForbidExtrasMixin
+
+    configure(ForbidExtrasMixin)
+
+    from multiconn_archicad.models.tapir.types import Coordinate2D
+    from multiconn_archicad.models.official.types import AddOnCommandParameters
+    from multiconn_archicad.models.base import APIModel
+
+    # 1. Define a custom leaf model to test custom override behavior
+    class CustomPermissiveModel(APIModel):
+        model_config = ConfigDict(extra="allow")
+        name: str
+
+    # 2. Coordinate2D (no local override) inherits extra="forbid" from mixin
+    with pytest.raises(ValidationError):
+        Coordinate2D(x=1.0, y=2.0, extra_key="fails")
+
+    # 3. CustomPermissiveModel explicitly declares extra="allow" -> overrides mixin
+    custom = CustomPermissiveModel(name="test", arbitrary_dynamic_field=999)
+    assert custom.name == "test"
+    assert getattr(custom, "arbitrary_dynamic_field") == 999
+
+    # 4. Built-in AddOnCommandParameters (which has extra="allow") also overrides mixin
+    addon_params = AddOnCommandParameters.model_validate({
+        "archicadCustomPayload": {"guid": "123-abc"},
+        "speedMultiplier": 1.5,
+    })
+    dumped = addon_params.model_dump()
+    assert dumped["archicadCustomPayload"] == {"guid": "123-abc"}
+    assert dumped["speedMultiplier"] == 1.5
+
+
+# =========================================================================
+# COMPLETE HIERARCHY: Multi-Mixin Composition + Overrides
+# =========================================================================
+
+def test_full_precedence_hierarchy_with_multiple_mixins(clean_models):
+    """
+    Proves the full stack in action simultaneously:
+    - Baseline: populate_by_name=True
+    - Mixin 1 (ForbidExtrasMixin): extra="forbid"
+    - Mixin 2 (FrozenMixin): frozen=True
+    - Mixin 3 (StrictMixin): strict=True
+    - Leaf Model: overrides extra="allow" and frozen=False
+    """
+    from multiconn_archicad.models.config import configure
+    from multiconn_archicad.models.mixins import ForbidExtrasMixin, FrozenMixin, StrictMixin
+
+    # Configure multiple mixins with different ConfigDict keys
+    configure(ForbidExtrasMixin, FrozenMixin, StrictMixin)
+
+    from multiconn_archicad.models.base import APIModel
+    from multiconn_archicad.models.tapir.types import Coordinate2D
+
+    # 1. Inspect APIModel merged config
+    assert APIModel.model_config.get("populate_by_name") is True  # From Baseline
+    assert APIModel.model_config.get("extra") == "forbid"         # From ForbidExtrasMixin
+    assert APIModel.model_config.get("frozen") is True            # From FrozenMixin
+    assert APIModel.model_config.get("strict") is True            # From StrictMixin
+
+    # 2. Verify standard model obeys all mixins
+    coord = Coordinate2D(x=1.0, y=2.0)
+
+    # Obey StrictMixin (no type coercion like "1.0" -> 1.0)
+    with pytest.raises(ValidationError):
+        Coordinate2D.model_validate({"x": "1.0", "y": 2.0})
+
+    # Obey ForbidExtrasMixin
+    with pytest.raises(ValidationError):
+        Coordinate2D.model_validate({"x": 1.0, "y": 2.0, "extra": "fails"})
+
+    # Obey FrozenMixin
+    with pytest.raises(ValidationError):
+        coord.x = 99.0
+
+    # 3. Leaf model can selectively override any of these settings
+    class DynamicMutableModel(APIModel):
+        model_config = ConfigDict(extra="allow", frozen=False)
+        title: str
+
+    mutable_instance = DynamicMutableModel(title="Initial", extra_tag="Allowed")
+    mutable_instance.title = "Modified"  # Mutation succeeds (overrode frozen=True)
+    assert mutable_instance.title == "Modified"
+    assert getattr(mutable_instance, "extra_tag") == "Allowed"  # Extra key succeeds (overrode extra="forbid")

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -25,10 +25,10 @@ def test_lock_enforcement_in_isolated_process():
     code = """
 import multiconn_archicad.models.tapir.commands
 from multiconn_archicad.models.config import configure
-from multiconn_archicad.models.mixins import StrictValidationMixin
+from multiconn_archicad.models.mixins import ForbidExtrasMixin
 
 # This must raise RuntimeError and exit with an error code
-configure(StrictValidationMixin)
+configure(ForbidExtrasMixin)
 """
     result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
     assert result.returncode != 0

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -72,13 +72,30 @@ def test_importing_config_does_not_lock_or_import_models(clean_models):
 # REQUIREMENT 3: Mixins properly alter model behavior
 # =========================================================================
 
-def test_strict_validation_mixin_alters_behavior(clean_models):
-    """Verifies StrictValidationMixin rejects unknown keys but respects context bypass."""
+def test_forbid_extras_mixin_alters_behavior(clean_models):
+    """Verifies ForbidExtrasMixin natively rejects extra keys with standard ValidationError."""
     from multiconn_archicad.models.config import configure
-    from multiconn_archicad.models.mixins import StrictValidationMixin
+    from multiconn_archicad.models.mixins import ForbidExtrasMixin
 
-    # Configure strict mode
-    configure(StrictValidationMixin)
+    configure(ForbidExtrasMixin)
+
+    from multiconn_archicad.models.tapir.types import Coordinate2D
+
+    # 1. Unknown field -> Must raise ValidationError
+    with pytest.raises(ValidationError):
+        Coordinate2D(x=1.0, y=2.0, fake_z_coordinate=3.0)
+
+    # 2. Valid input passes
+    coord = Coordinate2D(x=1.0, y=2.0)
+    assert coord.x == 1.0
+
+
+def test_contextual_forbid_extras_mixin_alters_behavior(clean_models):
+    """Verifies ContextualForbidExtrasMixin rejects unknown keys but respects context bypass."""
+    from multiconn_archicad.models.config import configure
+    from multiconn_archicad.models.mixins import ContextualForbidExtrasMixin
+
+    configure(ContextualForbidExtrasMixin)
 
     from multiconn_archicad.models.tapir.types import Coordinate2D
 
@@ -89,9 +106,26 @@ def test_strict_validation_mixin_alters_behavior(clean_models):
     # 2. Context bypass -> Must safely ignore unknown field
     valid_with_context = Coordinate2D.model_validate(
         {"x": 1.0, "y": 2.0, "future_api_field": "test"},
-        context={"ignore_extra_keys": True}
+        context={"ignore_extra_keys": True},
     )
     assert valid_with_context.x == 1.0
+
+
+def test_strict_mixin_alters_behavior(clean_models):
+    """Verifies StrictMixin enforces strict types without automatic coercion."""
+    from multiconn_archicad.models.config import configure
+    from multiconn_archicad.models.mixins import StrictMixin
+
+    configure(StrictMixin)
+
+    from multiconn_archicad.models.tapir.types import Coordinate2D
+
+    # In strict mode, string "1.0" should not be coerced to float
+    with pytest.raises(ValidationError):
+        Coordinate2D.model_validate({"x": "1.0", "y": 2.0})
+
+    valid = Coordinate2D(x=1.0, y=2.0)
+    assert valid.x == 1.0
 
 
 def test_frozen_mixin_alters_behavior(clean_models):
@@ -123,7 +157,6 @@ def test_omit_defaults_mixin_alters_behavior(clean_models):
 
     from multiconn_archicad.models.tapir.types import BeamData, Coordinate2D
 
-    # BeamData has many optional fields defaulting to None (e.g. offset, slantAngle)
     beam = BeamData(
         begCoordinate=Coordinate2D(x=0.0, y=0.0),
         endCoordinate=Coordinate2D(x=5.0, y=0.0),
@@ -131,28 +164,25 @@ def test_omit_defaults_mixin_alters_behavior(clean_models):
     )
 
     dumped = beam.model_dump()
-
-    # Defaults like slantAngle (None) should be omitted
     assert "slantAngle" not in dumped
     assert "begCoordinate" in dumped
 
 
 def test_multiple_mixins_combine_cooperatively(clean_models):
     """
-    Verifies that all 4 mixins (Strict, Frozen, StripWhitespace, OmitDefaults)
-    can be configured together and that all their behaviors execute simultaneously.
+    Verifies that multiple mixins (ForbidExtras, Frozen, StripWhitespace, OmitDefaults)
+    can be configured together and execute simultaneously.
     """
     from multiconn_archicad.models.config import configure
     from multiconn_archicad.models.mixins import (
-        StrictValidationMixin,
+        ForbidExtrasMixin,
         FrozenMixin,
         StripWhitespaceMixin,
         OmitDefaultsMixin,
     )
 
-    # 1. Configure with all 4 mixins simultaneously
     configure(
-        StrictValidationMixin,
+        ForbidExtrasMixin,
         FrozenMixin,
         StripWhitespaceMixin,
         OmitDefaultsMixin,
@@ -160,9 +190,7 @@ def test_multiple_mixins_combine_cooperatively(clean_models):
 
     from multiconn_archicad.models.tapir.types import DetailData, BeamData, Coordinate2D
 
-    # =========================================================================
-    # BEHAVIOR 1: StripWhitespaceMixin (Trims whitespace from strings)
-    # =========================================================================
+    # 1. StripWhitespaceMixin
     detail = DetailData(
         name="   Foundation Detail A-A   ",
         referenceId="   DET-001   ",
@@ -170,93 +198,67 @@ def test_multiple_mixins_combine_cooperatively(clean_models):
     assert detail.name == "Foundation Detail A-A"
     assert detail.referenceId == "DET-001"
 
-    # =========================================================================
-    # BEHAVIOR 2: StrictValidationMixin (Rejects unknown parameters)
-    # =========================================================================
-    with pytest.raises(ValueError, match="Extra fields not allowed in DetailData"):
+    # 2. ForbidExtrasMixin
+    with pytest.raises(ValidationError):
         DetailData(
             name="Roof Section",
             referenceId="DET-002",
             hallucinated_param="invalid_field",
         )
 
-    # =========================================================================
-    # BEHAVIOR 3: FrozenMixin (Immutable & Hashable)
-    # =========================================================================
-    # Mutating an attribute must raise a Pydantic ValidationError
+    # 3. FrozenMixin
     with pytest.raises(ValidationError):
         detail.name = "Changed Name"
 
-    # Must be hashable so it can be added to sets and used as dict keys
     detail_set = {detail}
     assert detail in detail_set
 
-    # =========================================================================
-    # BEHAVIOR 4: OmitDefaultsMixin (Default/None values excluded from dumps)
-    # =========================================================================
+    # 4. OmitDefaultsMixin
     beam = BeamData(
         begCoordinate=Coordinate2D(x=0.0, y=0.0),
         endCoordinate=Coordinate2D(x=10.0, y=0.0),
         zCoordinate=0.0,
-        # offset, slantAngle, arcAngle, etc. default to None
     )
     dumped = beam.model_dump()
-
     assert "begCoordinate" in dumped
-    assert "offset" not in dumped
     assert "slantAngle" not in dumped
-    assert "arcAngle" not in dumped
 
 
-def test_extra_allow_models_permit_arbitrary_keys_under_strict_mode(clean_models):
+def test_extra_allow_models_permit_arbitrary_keys_under_forbid_extras(clean_models):
     """
     Verifies that models explicitly configured with extra='allow' (AddOnCommandParameters
-    and AddOnCommandResponse) continue to accept arbitrary keys, even when StrictValidationMixin
-    is globally enabled.
+    and AddOnCommandResponse) override base extra='forbid' and accept arbitrary keys.
     """
     from multiconn_archicad.models.config import configure
-    from multiconn_archicad.models.mixins import StrictValidationMixin
+    from multiconn_archicad.models.mixins import ForbidExtrasMixin
 
-    # 1. Enable strict validation globally
-    configure(StrictValidationMixin)
+    configure(ForbidExtrasMixin)
 
-    # Import both standard models and the Add-On models
     from multiconn_archicad.models.tapir.types import Coordinate2D
     from multiconn_archicad.models.official.types import (
         AddOnCommandParameters,
         AddOnCommandResponse,
     )
 
-    # =========================================================================
-    # 1. Verify that standard models are STILL strictly locked down
-    # =========================================================================
-    with pytest.raises(ValueError, match="Extra fields not allowed in Coordinate2D"):
+    # Standard model must reject extra keys
+    with pytest.raises(ValidationError):
         Coordinate2D(x=1.0, y=2.0, forbidden_key="must_fail")
 
-    # =========================================================================
-    # 2. Verify AddOnCommandParameters allows arbitrary input keys
-    # =========================================================================
+    # AddOnCommandParameters allows extra keys
     custom_params = AddOnCommandParameters.model_validate({
         "customAddonKey": "customValue",
         "nestedData": {"flag": True, "count": 42},
         "targetStory": 1,
     })
-
     dumped_params = custom_params.model_dump()
     assert dumped_params["customAddonKey"] == "customValue"
     assert dumped_params["nestedData"] == {"flag": True, "count": 42}
-    assert dumped_params["targetStory"] == 1
 
-    # =========================================================================
-    # 3. Verify AddOnCommandResponse allows arbitrary response keys
-    # =========================================================================
+    # AddOnCommandResponse allows extra keys
     custom_response = AddOnCommandResponse.model_validate({
         "status": "OK",
-        "returnedGuids": ["uuid-1234", "uuid-5678"],
-        "executionTimeMs": 12.5,
+        "returnedGuids": ["uuid-1234"],
     })
-
     dumped_response = custom_response.model_dump()
     assert dumped_response["status"] == "OK"
-    assert dumped_response["returnedGuids"] == ["uuid-1234", "uuid-5678"]
-    assert dumped_response["executionTimeMs"] == 12.5
+    assert dumped_response["returnedGuids"] == ["uuid-1234"]


### PR DESCRIPTION
Established a desiered config precedence order: Default -> Mixin -> Concrete Model. In order to achice it we manually combine a new, explicit _DEFAULT_CONFIG, and the config dicts of the mixins

### other changes:
- `ForbidExtrasMixin` uses native `ConfigDict(extra="forbid")` for performance.
- `ContextualForbidExtrasMixin` (old `StrictValidationMixin`) preserved for context-based `extra` control.
- `StrictMixin` added for `strict=True` type validation.
- Tests confirm the new config precedence (Default -> Mixin -> Concrete Model) works as expected.