### PR TITLE
feat: base model now rejects inf/nan

### DIFF
--- a/src/multiconn_archicad/models/base.py
+++ b/src/multiconn_archicad/models/base.py
@@ -6,6 +6,7 @@ _DEFAULT_CONFIG: dict[str, Any] = {
     "extra": "ignore",
     "populate_by_name": True,
     "serialize_by_alias": True,
+    "allow_inf_nan": False,
 }
 
 _merged_config = dict(_DEFAULT_CONFIG)


### PR DESCRIPTION
the base model of the Pydantic schema models, APIModel now rejects inf/nan